### PR TITLE
Fix missing closing brace in log-scaled bar chart generator

### DIFF
--- a/analyse/src/ignoreCoverage/cliGenerateDetectedDataClumpsChartDivergingLogScaledBarChart.ts
+++ b/analyse/src/ignoreCoverage/cliGenerateDetectedDataClumpsChartDivergingLogScaledBarChart.ts
@@ -94,6 +94,8 @@ function generateLogDeltaChartPython(projectToAmountDataClumps: Record<string, n
             "        fontsize=8, color=\"black\"\n" +
             "    )";
 
+    }
+
     let showGuideLinesForProjects = true;
     if (showGuideLinesForProjects) {
         fileContent += "# Nach dem Zeichnen der Balken\n" +


### PR DESCRIPTION
## Summary
- close conditional block in `cliGenerateDetectedDataClumpsChartDivergingLogScaledBarChart.ts` to restore TypeScript compilation

## Testing
- `cd analyse && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c304aa1e5c8330b1eb850a4ad0d270