### PR TITLE
fix: include config in eslint

### DIFF
--- a/analyse/tsconfig.eslint.json
+++ b/analyse/tsconfig.eslint.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["analyse/**/*.ts", "src/**/*.ts"],
+  "include": ["**/*.ts"],
   "exclude": ["node_modules", "**/*.test.ts", "build", "coverage"],
 }


### PR DESCRIPTION
## Summary
- make ESLint include all TypeScript files so configs like `jest.config.ts` are linted

## Testing
- `yarn lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3199d078c8330b28c3d983c96ab87