### PR TITLE
Refactor detectors to reduce data clumps

### DIFF
--- a/analyse/src/ignoreCoverage/ProjectInfo.ts
+++ b/analyse/src/ignoreCoverage/ProjectInfo.ts
@@ -1,0 +1,7 @@
+import { Timer } from './Timer';
+
+export interface ProjectInfo {
+  project_url: string | null;
+  project_name: string;
+  timer: Timer;
+}

--- a/analyse/src/ignoreCoverage/detector/Detector.ts
+++ b/analyse/src/ignoreCoverage/detector/Detector.ts
@@ -3,6 +3,7 @@ import { DetectorDataClumpsMethods } from './DetectorDataClumpsMethods';
 import { DetectorDataClumpsFields } from './DetectorDataClumpsFields';
 import { DataClumpsTypeContext } from 'data-clumps-type-context';
 import { Timer } from '../Timer';
+import { ProjectInfo } from '../ProjectInfo';
 import path from 'path';
 import fs from 'fs';
 import { DetectorDataClumpsMethodsToOtherFields } from './DetectorDataClumpsMethodsToOtherFields';
@@ -453,11 +454,9 @@ export class InvertedIndexSoftwareProject {
 export class Detector {
   public options: DetectorOptions;
   public softwareProjectDicts: SoftwareProjectDicts;
-  public timer: Timer;
+  public projectInfo: ProjectInfo;
   public progressCallback: any;
   public target_language: string;
-  public project_url: string | null;
-  public project_name: string;
   public project_version: string | null;
   public project_commit_hash: string | null;
   public project_tag: string | null;
@@ -468,15 +467,29 @@ export class Detector {
     return getDefaultValuesFromPartialOptions(options || {});
   }
 
-  public constructor(softwareProjectDicts: SoftwareProjectDicts, options: Partial<DetectorOptions> | null, progressCallback: any, project_url: string | null, project_name: string | null, project_version: string | null, project_commit_hash: string | null, project_tag: string | null, project_commit_date: string | null, additional?: any, target_language?: string) {
+  public constructor(
+    softwareProjectDicts: SoftwareProjectDicts,
+    options: Partial<DetectorOptions> | null,
+    progressCallback: any,
+    project_url: string | null,
+    project_name: string | null,
+    project_version: string | null,
+    project_commit_hash: string | null,
+    project_tag: string | null,
+    project_commit_date: string | null,
+    additional?: any,
+    target_language?: string
+  ) {
     this.options = Detector.getDefaultOptions(options || {});
     this.softwareProjectDicts = softwareProjectDicts;
-    this.timer = new Timer();
+    this.projectInfo = {
+      project_url: project_url || 'unknown',
+      project_name: project_name || 'unknown',
+      timer: new Timer(),
+    };
     this.progressCallback = progressCallback;
 
     this.target_language = target_language || 'java';
-    this.project_url = project_url || 'unknown';
-    this.project_name = project_name || 'unknown';
     this.project_version = project_version || 'unknown';
     this.project_commit_hash = project_commit_hash || 'unknown';
     this.project_tag = project_tag || null;
@@ -487,7 +500,7 @@ export class Detector {
   }
 
   public async detect(): Promise<DataClumpsTypeContext> {
-    this.timer.start();
+    this.projectInfo.timer.start();
 
     let keys_for_classes_or_interfaces = Object.keys(this.softwareProjectDicts.dictClassOrInterface);
     let file_paths = {};
@@ -520,8 +533,8 @@ export class Detector {
         amount_data_clumps: null,
       },
       project_info: {
-        project_url: this.project_url,
-        project_name: this.project_name,
+        project_url: this.projectInfo.project_url,
+        project_name: this.projectInfo.project_name,
         project_version: this.project_version,
         project_commit_hash: this.project_commit_hash,
         project_tag: this.project_tag,
@@ -613,7 +626,7 @@ export class Detector {
 
     // timeout for testing
 
-    this.timer.stop();
+    this.projectInfo.timer.stop();
 
     //console.log("Detecting software project for data clumps (done)")
 

--- a/analyse/src/ignoreCoverage/detector/DetectorBase.ts
+++ b/analyse/src/ignoreCoverage/detector/DetectorBase.ts
@@ -1,0 +1,11 @@
+import { DetectorOptions } from './Detector';
+
+export abstract class DetectorBase {
+  public options: DetectorOptions;
+  public progressCallback: any;
+
+  protected constructor(options: DetectorOptions, parseOptions: (raw: DetectorOptions) => DetectorOptions, progressCallback?: any) {
+    this.options = parseOptions(JSON.parse(JSON.stringify(options)));
+    this.progressCallback = progressCallback;
+  }
+}

--- a/analyse/src/ignoreCoverage/detector/DetectorDataClumpsFields.ts
+++ b/analyse/src/ignoreCoverage/detector/DetectorDataClumpsFields.ts
@@ -5,6 +5,7 @@ import { DataClumpTypeContext } from 'data-clumps-type-context';
 import { ClassOrInterfaceTypeContext, MemberFieldParameterTypeContext, MethodTypeContext } from './../ParsedAstTypes';
 import { SoftwareProjectDicts } from './../SoftwareProject';
 import { DetectorOptions, InvertedIndexSoftwareProject } from './Detector';
+import { DetectorBase } from './DetectorBase';
 
 // TODO refactor this method to Detector since there is already the creation, so why not the refactoring
 function getParsedValuesFromPartialOptions(rawOptions: DetectorOptions): DetectorOptions {
@@ -28,15 +29,11 @@ type ContextAnalyseDataClumpFieldField = {
   invertedIndexSoftwareProject: InvertedIndexSoftwareProject;
 };
 
-export class DetectorDataClumpsFields {
+export class DetectorDataClumpsFields extends DetectorBase {
   public static TYPE = 'fields_to_fields_data_clump';
 
-  public options: DetectorOptions;
-  public progressCallback: any;
-
   public constructor(options: DetectorOptions, progressCallback?: any) {
-    this.options = getParsedValuesFromPartialOptions(options);
-    this.progressCallback = progressCallback;
+    super(options, getParsedValuesFromPartialOptions, progressCallback);
   }
 
   public async detect(softwareProjectDicts: SoftwareProjectDicts, invertedIndexSoftwareProject: InvertedIndexSoftwareProject): Promise<Dictionary<DataClumpTypeContext> | null> {

--- a/analyse/src/ignoreCoverage/detector/DetectorDataClumpsMethodsToOtherFields.ts
+++ b/analyse/src/ignoreCoverage/detector/DetectorDataClumpsMethodsToOtherFields.ts
@@ -3,6 +3,7 @@ import { DataClumpTypeContext, Dictionary } from 'data-clumps-type-context';
 import { ClassOrInterfaceTypeContext, MethodTypeContext } from './../ParsedAstTypes';
 import { SoftwareProjectDicts } from './../SoftwareProject';
 import { DetectorOptions, DetectorOptionsInformation, InvertedIndexSoftwareProject } from './Detector';
+import { DetectorBase } from './DetectorBase';
 import { DetectorDataClumpsFields } from './DetectorDataClumpsFields';
 import { ContextAnalyseDataClumpParameter } from './DetectorDataClumpsMethods';
 
@@ -24,15 +25,11 @@ function getParsedValuesFromPartialOptions(rawOptions: DetectorOptions): Detecto
   return rawOptions;
 }
 
-export class DetectorDataClumpsMethodsToOtherFields {
+export class DetectorDataClumpsMethodsToOtherFields extends DetectorBase {
   public static TYPE = 'parameters_to_fields_data_clump';
 
-  public options: DetectorOptions;
-  public progressCallback: any;
-
   public constructor(options: DetectorOptions, progressCallback?: any) {
-    this.options = getParsedValuesFromPartialOptions(JSON.parse(JSON.stringify(options)));
-    this.progressCallback = progressCallback;
+    super(options, getParsedValuesFromPartialOptions, progressCallback);
   }
 
   /**

--- a/analyse/src/ignoreCoverage/detector/DetectorDataClumpsMethodsToOtherMethods.ts
+++ b/analyse/src/ignoreCoverage/detector/DetectorDataClumpsMethodsToOtherMethods.ts
@@ -3,6 +3,7 @@ import { DataClumpTypeContext, Dictionary } from 'data-clumps-type-context';
 import { MethodTypeContext } from './../ParsedAstTypes';
 import { SoftwareProjectDicts } from './../SoftwareProject';
 import { DetectorOptions, DetectorOptionsInformation, InvertedIndexSoftwareProject } from './Detector';
+import { DetectorBase } from './DetectorBase';
 import { ContextAnalyseDataClumpParameter } from './DetectorDataClumpsMethods';
 
 // TODO refactor this method to Detector since there is already the creation, so why not the refactoring
@@ -20,15 +21,11 @@ function getParsedValuesFromPartialOptions(rawOptions: DetectorOptions): Detecto
   return rawOptions;
 }
 
-export class DetectorDataClumpsMethodsToOtherMethods {
+export class DetectorDataClumpsMethodsToOtherMethods extends DetectorBase {
   public static TYPE = 'parameters_to_parameters_data_clump';
 
-  public options: DetectorOptions;
-  public progressCallback: any;
-
   public constructor(options: DetectorOptions, progressCallback?: any) {
-    this.options = getParsedValuesFromPartialOptions(JSON.parse(JSON.stringify(options)));
-    this.progressCallback = progressCallback;
+    super(options, getParsedValuesFromPartialOptions, progressCallback);
   }
 
   /**

--- a/analyse/src/ignoreCoverage/parsers/helper/ParserHelperDigitalTwinsDefinitionLanguageFileParser.ts
+++ b/analyse/src/ignoreCoverage/parsers/helper/ParserHelperDigitalTwinsDefinitionLanguageFileParser.ts
@@ -3,6 +3,12 @@ import fs from 'fs/promises';
 import path from 'path';
 import { AstPosition, ClassOrInterfaceTypeContext, MemberFieldParameterTypeContext, MethodParameterTypeContext, MethodTypeContext } from '../../ParsedAstTypes';
 
+interface DtdlParseContext {
+  id: string;
+  classOrInterface: ClassOrInterfaceTypeContext;
+  mapDtmiIdToRawJson: Map<string, any>;
+}
+
 export class ParserHelperDigitalTwinsDefinitionLanguageFileParser {
   constructor() {}
 
@@ -334,10 +340,11 @@ export class ParserHelperDigitalTwinsDefinitionLanguageFileParser {
       const classOrInterface = new ClassOrInterfaceTypeContext(id, displayName, 'interface', usedFilePath);
 
       // jetzt die Inhalte verarbeiten (analog zum Azure-Parser)
-      this.setFieldsFromProperty(id, classOrInterface, mapDtmiIdToRawJson);
-      this.setMethodsFromOperation(id, classOrInterface, mapDtmiIdToRawJson);
-      this.setExtendsFromInterface(id, classOrInterface, mapDtmiIdToRawJson);
-      this.setImplementsFromInterface(id, classOrInterface, mapDtmiIdToRawJson);
+      const context: DtdlParseContext = { id, classOrInterface, mapDtmiIdToRawJson };
+      this.setFieldsFromProperty(context);
+      this.setMethodsFromOperation(context);
+      this.setExtendsFromInterface(context);
+      this.setImplementsFromInterface(context);
 
       dictOfClassesOrInterfaces.set(id, classOrInterface);
     }
@@ -422,10 +429,11 @@ export class ParserHelperDigitalTwinsDefinitionLanguageFileParser {
 
       const classOrInterface = new ClassOrInterfaceTypeContext(id, displayName, type, usedFilePath);
 
-      this.setFieldsFromProperty(id, classOrInterface, mapDtmiIdToRawJson);
-      this.setMethodsFromOperation(id, classOrInterface, mapDtmiIdToRawJson);
-      this.setExtendsFromInterface(id, classOrInterface, mapDtmiIdToRawJson);
-      this.setImplementsFromInterface(id, classOrInterface, mapDtmiIdToRawJson);
+      const context: DtdlParseContext = { id, classOrInterface, mapDtmiIdToRawJson };
+      this.setFieldsFromProperty(context);
+      this.setMethodsFromOperation(context);
+      this.setExtendsFromInterface(context);
+      this.setImplementsFromInterface(context);
 
       dictOfClassesOrInterfaces.set(id, classOrInterface);
       //console.log("---");
@@ -437,7 +445,8 @@ export class ParserHelperDigitalTwinsDefinitionLanguageFileParser {
     return dictOfClassesOrInterfaces;
   }
 
-  private setExtendsFromInterface(id: string, classOrInterface: ClassOrInterfaceTypeContext, mapDtmiIdToRawJson: Map<string, any>) {
+  private setExtendsFromInterface(context: DtdlParseContext) {
+    const { id, classOrInterface, mapDtmiIdToRawJson } = context;
     const raw = mapDtmiIdToRawJson.get(id);
     if (raw.extends) {
       if (Array.isArray(raw.extends)) {
@@ -458,7 +467,8 @@ export class ParserHelperDigitalTwinsDefinitionLanguageFileParser {
     return ['definedBy', 'specifiedBy'];
   }
 
-  private setImplementsFromInterface(id: string, classOrInterface: ClassOrInterfaceTypeContext, mapDtmiIdToRawJson: Map<string, any>) {
+  private setImplementsFromInterface(context: DtdlParseContext) {
+    const { id, classOrInterface, mapDtmiIdToRawJson } = context;
     // DTDL hat kein "implements", sondern "extends" für Interfaces
     // Diese Methode ist hier nur der Vollständigkeit halber
     // Wir schauen uns aber die "definedBy" Relationships an, die oft wie "implements" wirken
@@ -483,7 +493,8 @@ export class ParserHelperDigitalTwinsDefinitionLanguageFileParser {
     }
   }
 
-  private setMethodsFromOperation(id: string, classOrInterface: ClassOrInterfaceTypeContext, mapDtmiIdToRawJson: Map<string, any>) {
+  private setMethodsFromOperation(context: DtdlParseContext) {
+    const { id, classOrInterface, mapDtmiIdToRawJson } = context;
     const raw = mapDtmiIdToRawJson.get(id);
     const contentsFromRaw = raw?.contents || [];
 
@@ -567,7 +578,8 @@ export class ParserHelperDigitalTwinsDefinitionLanguageFileParser {
     }
   }
 
-  private setFieldsFromProperty(id: string, classOrInterface: ClassOrInterfaceTypeContext, mapDtmiIdToRawJson: Map<string, any>) {
+  private setFieldsFromProperty(context: DtdlParseContext) {
+    const { id, classOrInterface, mapDtmiIdToRawJson } = context;
     //console.log(`Interface ${interfaceInfo.id}`);
     /**
      * Das Problem ist, dass @azure/dtdl-parser gibt dir bei InterfaceInfo.contents immer alle Contents, also auch die geerbten aus extends


### PR DESCRIPTION
## Summary
- centralize detector options and progress handling in `DetectorBase`
- add `ProjectInfo` to share project metadata and timers
- consolidate DTDL parser parameters into a context object

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3219ae83c83308d23ebe787208ec2