### PR TITLE
Add constructor metadata to TypeScript AST model

### DIFF
--- a/analyse/src/ignoreCoverage/astGenerator/pmd-java-custom/src/main/java/net/sourceforge/pmd/examples/java/rules/parsedAstTypes/ClassOrInterfaceTypeContext.java
+++ b/analyse/src/ignoreCoverage/astGenerator/pmd-java-custom/src/main/java/net/sourceforge/pmd/examples/java/rules/parsedAstTypes/ClassOrInterfaceTypeContext.java
@@ -9,6 +9,7 @@ public class ClassOrInterfaceTypeContext extends AstElementTypeContext {
     public List<String> modifiers = new ArrayList<String>();
     public Map<String, MemberFieldParameterTypeContext> fields = new HashMap<String, MemberFieldParameterTypeContext>();
     public Map<String, MethodTypeContext> methods = new HashMap<String, MethodTypeContext>();
+    public Map<String, MethodTypeContext> constructors = new HashMap<String, MethodTypeContext>();
     public String file_path;
     public boolean anonymous;
     public boolean auxclass; // true: wont be analysed. the class is only an aux class in order to support the hierarchy.

--- a/analyse/src/ignoreCoverage/parsers/ParserHelperTypeScript.ts
+++ b/analyse/src/ignoreCoverage/parsers/ParserHelperTypeScript.ts
@@ -81,6 +81,36 @@ export class ParserHelperTypeScript extends ParserBase implements ParserInterfac
           ctx.methods[methodCtx.key] = methodCtx;
         }
 
+        for (const ctor of cls.getConstructors()) {
+          const parameterInfos = ctor.getParameters().map((param) => ({
+            name: param.getName(),
+            type: param.getType().getText(),
+          }));
+          const signature = parameterInfos
+            .map((param) => `${param.type} ${param.name}`)
+            .join(', ');
+          const ctorKey = `constructor(${signature})`;
+          const ctorCtx = new MethodTypeContext(ctorKey, 'constructor', undefined, false, ctx, 'constructor');
+          ctorCtx.modifiers = [];
+          if (ctor.hasModifier('public')) ctorCtx.modifiers.push('PUBLIC');
+          if (ctor.hasModifier('protected')) ctorCtx.modifiers.push('PROTECTED');
+          if (ctor.hasModifier('private')) ctorCtx.modifiers.push('PRIVATE');
+
+          for (const paramInfo of parameterInfos) {
+            const paramCtx = new MethodParameterTypeContext(
+              paramInfo.name,
+              paramInfo.name,
+              paramInfo.type,
+              [],
+              false,
+              ctorCtx,
+            );
+            ctorCtx.parameters.push(paramCtx);
+          }
+
+          ctx.constructors[ctorCtx.key] = ctorCtx;
+        }
+
         dict.set(ctx.key, ctx);
       }
 


### PR DESCRIPTION
### **User description**
## Summary
- extend the ParsedAstTypes TypeScript model with a constructors dictionary and constructor-aware MethodTypeContext initialisation
- normalise MethodTypeContext to capture return types and support constructor key generation
- teach the TypeScript parser to extract constructors, including signatures and parameter metadata

## Testing
- mvn -q test *(fails: no Maven project/POM in repository root)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3651ff288330a2c38fc16da4e243


___

### **Description**
- Introduced support for constructors in the TypeScript AST model.
- Enhanced `ClassOrInterfaceTypeContext` to include a `constructors` dictionary.
- Implemented constructor extraction in both TypeScript and Java parsers.
- Updated `MethodTypeContext` to differentiate between methods and constructors.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ParsedAstTypes.ts</strong><dd><code>Enhance TypeScript AST with Constructor Support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

analyse/src/ignoreCoverage/ParsedAstTypes.ts
<li>Added <code>constructors</code> dictionary to <code>ClassOrInterfaceTypeContext</code>.<br> <li> Updated object assignment to initialize <code>constructors</code>.<br> <li> Modified <code>MethodTypeContext</code> constructor to handle constructors.<br>


</details>


  </td>
  <td><a href="https://github.com/NilsBaumgartner1994/data-clumps-doctor/pull/39/files#diff-b718e7896178dc348fc9fad3fd888bedcdb3e8f77e2c07fd813595d594371eba">+20/-2</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>MyRule.java</strong><dd><code>Add Constructor Extraction Logic in Java AST</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

analyse/src/ignoreCoverage/astGenerator/pmd-java-custom/src/main/java/net/sourceforge/pmd/examples/java/rules/MyRule.java
<li>Implemented <code>extractConstructors</code> method to extract constructor details.<br> <li> Added logic to handle constructor parameters and modifiers.<br> <li> Updated class context to include extracted constructors.<br>


</details>


  </td>
  <td><a href="https://github.com/NilsBaumgartner1994/data-clumps-doctor/pull/39/files#diff-dcdaed1fe46f01410e571255d59494a87046dd7855c856ea5327281018331e81">+76/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ParserHelperTypeScript.ts</strong><dd><code>Implement Constructor Extraction in TypeScript Parser</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

analyse/src/ignoreCoverage/parsers/ParserHelperTypeScript.ts
<li>Added logic to extract constructors from TypeScript classes.<br> <li> Created <code>MethodTypeContext</code> instances for constructors.<br> <li> Captured constructor parameters and their modifiers.<br>


</details>


  </td>
  <td><a href="https://github.com/NilsBaumgartner1994/data-clumps-doctor/pull/39/files#diff-5712b1d8c1167ed79cfc4d22e46c92bd42538dd3813ef8f1de1c37030b9e98cd">+30/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

