### PR TITLE
Add TypeScript field-field data clump test infrastructure

### DIFF
--- a/analyse/jest.config.ts
+++ b/analyse/jest.config.ts
@@ -82,7 +82,10 @@ export default {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    '^@azure/dtdl-parser$': '<rootDir>/jest/mocks/azure-dtdl-parser.js',
+    '^@azure/logger$': '<rootDir>/jest/mocks/azure-logger.js',
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],
@@ -152,6 +155,7 @@ export default {
     '/coverage/',
     '/node_modules/',
     '/src/ignoreCoverage/',
+    '/tests/.*/source/',
   ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files

--- a/analyse/jest/mocks/azure-dtdl-parser.js
+++ b/analyse/jest/mocks/azure-dtdl-parser.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/analyse/jest/mocks/azure-logger.js
+++ b/analyse/jest/mocks/azure-logger.js
@@ -1,0 +1,16 @@
+const noop = () => undefined;
+
+module.exports = {
+  AzureLogger: {
+    info: noop,
+    warning: noop,
+    error: noop,
+  },
+  createClientLogger: () => ({
+    info: noop,
+    warning: noop,
+    error: noop,
+  }),
+  setLogLevel: noop,
+  setLogger: noop,
+};

--- a/analyse/src/ignoreCoverage/ParsedAstTypes.ts
+++ b/analyse/src/ignoreCoverage/ParsedAstTypes.ts
@@ -420,7 +420,7 @@ export class MethodTypeContext extends AstElementTypeContext {
     super(computedKey, name, type);
     this.modifiers = [];
     this.parameters = [];
-    this.classOrInterfaceKey = classOrInterface?.key;
+    this.classOrInterfaceKey = classOrInterface?.key ?? '';
     this.overrideAnnotation = overrideAnnotation;
     this.returnType = type;
   }

--- a/analyse/src/tests/DataClumpsDetectionTest.ts
+++ b/analyse/src/tests/DataClumpsDetectionTest.ts
@@ -1,6 +1,190 @@
+import path from 'path';
+import fs from 'fs';
+import crypto from 'crypto';
+import { SoftwareProjectDicts } from '../ignoreCoverage/SoftwareProject';
+import { Detector, DetectorOptions } from '../ignoreCoverage/detector/Detector';
+import { ParserInterface } from '../ignoreCoverage/parsers/ParserInterface';
+import { ParserHelperTypeScript } from '../ignoreCoverage/parsers/ParserHelperTypeScript';
+import { ClassOrInterfaceTypeContext } from '../ignoreCoverage/ParsedAstTypes';
+
+interface ScenarioConfig {
+  name: string;
+  language: string;
+  sourceDir: string;
+  expectedReportFile: string;
+  detectorOptions?: Partial<DetectorOptions>;
+}
+
+interface Scenario extends ScenarioConfig {
+  scenarioDir: string;
+  configPath: string;
+  sourcePath: string;
+  expectedReportPath: string;
+}
+
+type ParserWithDictionary = ParserInterface & {
+  parseSourceToDictOfClassesOrInterfaces: (
+    path: string,
+  ) => Promise<Map<string, ClassOrInterfaceTypeContext>>;
+};
+
+function ensureParserSupportsDictionary(parser: ParserInterface): ParserWithDictionary {
+  const candidate = parser as Partial<ParserWithDictionary>;
+  if (typeof candidate.parseSourceToDictOfClassesOrInterfaces !== 'function') {
+    throw new Error('Parser does not support direct dictionary generation.');
+  }
+  return parser as ParserWithDictionary;
+}
+
+function resolveScenarioPaths(configPath: string, rawConfig: ScenarioConfig): Scenario {
+  const scenarioDir = path.dirname(configPath);
+  return {
+    ...rawConfig,
+    scenarioDir,
+    configPath,
+    sourcePath: path.resolve(scenarioDir, rawConfig.sourceDir),
+    expectedReportPath: path.resolve(scenarioDir, rawConfig.expectedReportFile),
+  };
+}
+
+function discoverScenarioConfigs(baseDir: string): Scenario[] {
+  if (!fs.existsSync(baseDir)) {
+    return [];
+  }
+
+  const stack: string[] = [baseDir];
+  const scenarios: Scenario[] = [];
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (entry.isFile() && entry.name === 'test.config.json') {
+        const rawConfig = JSON.parse(fs.readFileSync(entryPath, 'utf8')) as ScenarioConfig;
+        scenarios.push(resolveScenarioPaths(entryPath, rawConfig));
+      }
+    }
+  }
+
+  return scenarios;
+}
+
+function resolveTestCasesBaseDir(): { baseDir: string; scenarios: Scenario[] } {
+  const candidates = [
+    path.resolve(__dirname, 'data-clumps/test-cases'),
+    path.resolve(__dirname, '..', '..', 'src/tests/data-clumps/test-cases'),
+  ];
+
+  for (const candidate of candidates) {
+    const scenarios = discoverScenarioConfigs(candidate);
+    if (scenarios.length > 0) {
+      return { baseDir: candidate, scenarios };
+    }
+  }
+
+  const fallback = candidates.find(candidate => fs.existsSync(candidate)) ?? candidates[0];
+  return { baseDir: fallback, scenarios: [] };
+}
+
+function createParser(language: string): ParserInterface {
+  switch (language.toLowerCase()) {
+    case 'typescript':
+      return new ParserHelperTypeScript();
+    default:
+      throw new Error(`Unsupported language: ${language}`);
+  }
+}
+
+async function buildSoftwareProjectDicts(parser: ParserInterface, sourcePath: string): Promise<SoftwareProjectDicts> {
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`Source path does not exist: ${sourcePath}`);
+  }
+
+  const typedParser = ensureParserSupportsDictionary(parser);
+  const classesOrInterfaces = await typedParser.parseSourceToDictOfClassesOrInterfaces(sourcePath);
+  const softwareProjectDicts = new SoftwareProjectDicts();
+  for (const classOrInterface of classesOrInterfaces.values()) {
+    softwareProjectDicts.loadClassOrInterface(classOrInterface);
+  }
+  return softwareProjectDicts;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const sortedEntries = Object.keys(val)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, key) => {
+          acc[key] = (val as Record<string, unknown>)[key];
+          return acc;
+        }, {});
+      return sortedEntries;
+    }
+    return val;
+  });
+}
+
+function computeDataClumpsHash(dataClumps: Record<string, unknown>): string {
+  const normalized = stableStringify(dataClumps);
+  return crypto.createHash('sha256').update(normalized).digest('hex');
+}
+
+async function runScenario(scenario: Scenario) {
+  const parser = createParser(scenario.language);
+  const softwareProjectDicts = await buildSoftwareProjectDicts(parser, scenario.sourcePath);
+  const detector = new Detector(
+    softwareProjectDicts,
+    scenario.detectorOptions ?? null,
+    null,
+    null,
+    scenario.name,
+    null,
+    null,
+    null,
+    null,
+    null,
+    scenario.language,
+  );
+  return detector.detect();
+}
+
+function loadExpectedReport(expectedReportPath: string) {
+  if (!fs.existsSync(expectedReportPath)) {
+    throw new Error(`Expected report file does not exist: ${expectedReportPath}`);
+  }
+  return JSON.parse(fs.readFileSync(expectedReportPath, 'utf8')) as { data_clumps: Record<string, unknown> };
+}
+
+function createScenarioTest(scenario: Scenario) {
+  test(scenario.name, async () => {
+    const actualReport = await runScenario(scenario);
+    const expectedReport = loadExpectedReport(scenario.expectedReportPath);
+
+    const actualHash = computeDataClumpsHash(actualReport.data_clumps);
+    const expectedHash = computeDataClumpsHash(expectedReport.data_clumps);
+
+    expect(actualHash).toBe(expectedHash);
+  });
+}
+
 function testAllLanguages() {
-  test('Example test', async () => {
-    expect('a').toBe('a');
+  describe('Data clumps detection scenarios', () => {
+    const { baseDir, scenarios } = resolveTestCasesBaseDir();
+
+    if (scenarios.length === 0) {
+      test('No data clumps scenarios found', () => {
+        throw new Error(`No scenarios discovered in ${baseDir}`);
+      });
+      return;
+    }
+
+    for (const scenario of scenarios) {
+      createScenarioTest(scenario);
+    }
   });
 }
 

--- a/analyse/src/tests/data-clumps/test-cases/field-field/typescript/patient-doctor/expected/report.json
+++ b/analyse/src/tests/data-clumps/test-cases/field-field/typescript/patient-doctor/expected/report.json
@@ -1,0 +1,223 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-19T11:30:35.181Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToClasses": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 2,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript field-field data clump between Patient and Doctor",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 0,
+    "number_of_data_fields": 6,
+    "number_of_method_parameters": 0
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "fields_to_fields_data_clump-Doctor.ts-Doctor.ts/class/Doctor-Patient.ts/class/Patient-firstnamelastnameage": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Doctor.ts-Doctor.ts/class/Doctor-Patient.ts/class/Patient-firstnamelastnameage",
+      "probability": 1,
+      "from_file_path": "Doctor.ts",
+      "from_class_or_interface_name": "Doctor",
+      "from_class_or_interface_key": "Doctor.ts/class/Doctor",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Patient.ts",
+      "to_class_or_interface_key": "Patient.ts/class/Patient",
+      "to_class_or_interface_name": "Doctor",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Doctor.ts/class/Doctor/memberField/firstname": {
+          "key": "Doctor.ts/class/Doctor/memberField/firstname",
+          "name": "firstname",
+          "type": "string",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/firstname",
+            "name": "firstname",
+            "type": "string",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Doctor.ts/class/Doctor/memberField/lastname": {
+          "key": "Doctor.ts/class/Doctor/memberField/lastname",
+          "name": "lastname",
+          "type": "string",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/lastname",
+            "name": "lastname",
+            "type": "string",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Doctor.ts/class/Doctor/memberField/age": {
+          "key": "Doctor.ts/class/Doctor/memberField/age",
+          "name": "age",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/age",
+            "name": "age",
+            "type": "number",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    },
+    "fields_to_fields_data_clump-Patient.ts-Patient.ts/class/Patient-Doctor.ts/class/Doctor-firstnamelastnameage": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Patient.ts-Patient.ts/class/Patient-Doctor.ts/class/Doctor-firstnamelastnameage",
+      "probability": 1,
+      "from_file_path": "Patient.ts",
+      "from_class_or_interface_name": "Patient",
+      "from_class_or_interface_key": "Patient.ts/class/Patient",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Doctor.ts",
+      "to_class_or_interface_key": "Doctor.ts/class/Doctor",
+      "to_class_or_interface_name": "Patient",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Patient.ts/class/Patient/memberField/firstname": {
+          "key": "Patient.ts/class/Patient/memberField/firstname",
+          "name": "firstname",
+          "type": "string",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor.ts/class/Doctor/memberField/firstname",
+            "name": "firstname",
+            "type": "string",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Patient.ts/class/Patient/memberField/lastname": {
+          "key": "Patient.ts/class/Patient/memberField/lastname",
+          "name": "lastname",
+          "type": "string",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor.ts/class/Doctor/memberField/lastname",
+            "name": "lastname",
+            "type": "string",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Patient.ts/class/Patient/memberField/age": {
+          "key": "Patient.ts/class/Patient/memberField/age",
+          "name": "age",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor.ts/class/Doctor/memberField/age",
+            "name": "age",
+            "type": "number",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    }
+  }
+}

--- a/analyse/src/tests/data-clumps/test-cases/field-field/typescript/patient-doctor/source/Doctor.ts
+++ b/analyse/src/tests/data-clumps/test-cases/field-field/typescript/patient-doctor/source/Doctor.ts
@@ -1,0 +1,11 @@
+export class Doctor {
+  public firstname: string;
+  public lastname: string;
+  public age: number;
+
+  constructor(firstname: string, lastname: string, age: number) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+    this.age = age;
+  }
+}

--- a/analyse/src/tests/data-clumps/test-cases/field-field/typescript/patient-doctor/source/Patient.ts
+++ b/analyse/src/tests/data-clumps/test-cases/field-field/typescript/patient-doctor/source/Patient.ts
@@ -1,0 +1,11 @@
+export class Patient {
+  public firstname: string;
+  public lastname: string;
+  public age: number;
+
+  constructor(firstname: string, lastname: string, age: number) {
+    this.firstname = firstname;
+    this.lastname = lastname;
+    this.age = age;
+  }
+}

--- a/analyse/src/tests/data-clumps/test-cases/field-field/typescript/patient-doctor/test.config.json
+++ b/analyse/src/tests/data-clumps/test-cases/field-field/typescript/patient-doctor/test.config.json
@@ -1,0 +1,10 @@
+{
+  "name": "TypeScript field-field data clump between Patient and Doctor",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "expected/report.json",
+  "detectorOptions": {
+    "sharedFieldsToFieldsAmountMinimum": 3,
+    "fastDetection": true
+  }
+}


### PR DESCRIPTION
## Summary
- add a scenario-driven Jest test that discovers data clump fixtures and validates detector output by hashing the `data_clumps` payload
- introduce a TypeScript patient/doctor field-field data clump example with configuration and expected report artifact
- stub Azure dependencies in Jest, ignore fixture source folders, and ensure method contexts default to a string key for compilation

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd3d9296748330a7c922ed128701b6