### PR TITLE
Add Java data clump scenario and tooling for test expectations

### DIFF
--- a/analyse/jest.config.ts
+++ b/analyse/jest.config.ts
@@ -156,6 +156,8 @@ export default {
     '/node_modules/',
     '/src/ignoreCoverage/',
     '/tests/.*/source/',
+    'generateMissingReports',
+    'scenarioUtils',
   ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files

--- a/analyse/package.json
+++ b/analyse/package.json
@@ -8,6 +8,7 @@
     "coverage": "jest --coverage",
     "test": "npm run build && npm run testOnly",
     "testOnly": "jest --coverage=false",
+    "generate-missing-test-reports": "npm run build && node ./build/tests/generateMissingReports.js",
     "start": "npm run build && node ./build/ignoreCoverage/development.js",
     "build": "rimraf ./build && tsc && cp -r ./src/ignoreCoverage/astGenerator ./build/ignoreCoverage && cp package.json ./build && cp ./../README.md ./build && cp ./../LICENSE.md ./build && npm run chmodCli",
     "chmodCli": "chmod +x ./build/ignoreCoverage/cli.js",

--- a/analyse/src/tests/DataClumpsDetectionTest.ts
+++ b/analyse/src/tests/DataClumpsDetectionTest.ts
@@ -1,112 +1,6 @@
-import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
-import { SoftwareProjectDicts } from '../ignoreCoverage/SoftwareProject';
-import { Detector, DetectorOptions } from '../ignoreCoverage/detector/Detector';
-import { ParserInterface } from '../ignoreCoverage/parsers/ParserInterface';
-import { ParserHelperTypeScript } from '../ignoreCoverage/parsers/ParserHelperTypeScript';
-import { ClassOrInterfaceTypeContext } from '../ignoreCoverage/ParsedAstTypes';
-
-interface ScenarioConfig {
-  name: string;
-  language: string;
-  sourceDir: string;
-  expectedReportFile: string;
-  detectorOptions?: Partial<DetectorOptions>;
-}
-
-interface Scenario extends ScenarioConfig {
-  scenarioDir: string;
-  configPath: string;
-  sourcePath: string;
-  expectedReportPath: string;
-}
-
-type ParserWithDictionary = ParserInterface & {
-  parseSourceToDictOfClassesOrInterfaces: (path: string) => Promise<Map<string, ClassOrInterfaceTypeContext>>;
-};
-
-function ensureParserSupportsDictionary(parser: ParserInterface): ParserWithDictionary {
-  const candidate = parser as Partial<ParserWithDictionary>;
-  if (typeof candidate.parseSourceToDictOfClassesOrInterfaces !== 'function') {
-    throw new Error('Parser does not support direct dictionary generation.');
-  }
-  return parser as ParserWithDictionary;
-}
-
-function resolveScenarioPaths(configPath: string, rawConfig: ScenarioConfig): Scenario {
-  const scenarioDir = path.dirname(configPath);
-  return {
-    ...rawConfig,
-    scenarioDir,
-    configPath,
-    sourcePath: path.resolve(scenarioDir, rawConfig.sourceDir),
-    expectedReportPath: path.resolve(scenarioDir, rawConfig.expectedReportFile),
-  };
-}
-
-function discoverScenarioConfigs(baseDir: string): Scenario[] {
-  if (!fs.existsSync(baseDir)) {
-    return [];
-  }
-
-  const stack: string[] = [baseDir];
-  const scenarios: Scenario[] = [];
-
-  while (stack.length > 0) {
-    const current = stack.pop()!;
-    const entries = fs.readdirSync(current, { withFileTypes: true });
-
-    for (const entry of entries) {
-      const entryPath = path.join(current, entry.name);
-      if (entry.isDirectory()) {
-        stack.push(entryPath);
-      } else if (entry.isFile() && entry.name === 'test.config.json') {
-        const rawConfig = JSON.parse(fs.readFileSync(entryPath, 'utf8')) as ScenarioConfig;
-        scenarios.push(resolveScenarioPaths(entryPath, rawConfig));
-      }
-    }
-  }
-
-  return scenarios;
-}
-
-function resolveTestCasesBaseDir(): { baseDir: string; scenarios: Scenario[] } {
-  const candidates = [path.resolve(__dirname, 'data-clumps/test-cases'), path.resolve(__dirname, '..', '..', 'src/tests/data-clumps/test-cases')];
-
-  for (const candidate of candidates) {
-    const scenarios = discoverScenarioConfigs(candidate);
-    if (scenarios.length > 0) {
-      return { baseDir: candidate, scenarios };
-    }
-  }
-
-  const fallback = candidates.find(candidate => fs.existsSync(candidate)) ?? candidates[0];
-  return { baseDir: fallback, scenarios: [] };
-}
-
-function createParser(language: string): ParserInterface {
-  switch (language.toLowerCase()) {
-    case 'typescript':
-      return new ParserHelperTypeScript();
-    default:
-      throw new Error(`Unsupported language: ${language}`);
-  }
-}
-
-async function buildSoftwareProjectDicts(parser: ParserInterface, sourcePath: string): Promise<SoftwareProjectDicts> {
-  if (!fs.existsSync(sourcePath)) {
-    throw new Error(`Source path does not exist: ${sourcePath}`);
-  }
-
-  const typedParser = ensureParserSupportsDictionary(parser);
-  const classesOrInterfaces = await typedParser.parseSourceToDictOfClassesOrInterfaces(sourcePath);
-  const softwareProjectDicts = new SoftwareProjectDicts();
-  for (const classOrInterface of classesOrInterfaces.values()) {
-    softwareProjectDicts.loadClassOrInterface(classOrInterface);
-  }
-  return softwareProjectDicts;
-}
+import { Scenario, resolveTestCasesBaseDir, runScenario } from './data-clumps/scenarioUtils';
 
 function stableStringify(value: unknown): string {
   return JSON.stringify(value, (_key, val) => {
@@ -128,13 +22,6 @@ function computeDataClumpsHash(dataClumps: Record<string, unknown>): string {
   return crypto.createHash('sha256').update(normalized).digest('hex');
 }
 
-async function runScenario(scenario: Scenario) {
-  const parser = createParser(scenario.language);
-  const softwareProjectDicts = await buildSoftwareProjectDicts(parser, scenario.sourcePath);
-  const detector = new Detector(softwareProjectDicts, scenario.detectorOptions ?? null, null, null, scenario.name, null, null, null, null, null, scenario.language);
-  return detector.detect();
-}
-
 function loadExpectedReport(expectedReportPath: string) {
   if (!fs.existsSync(expectedReportPath)) {
     throw new Error(`Expected report file does not exist: ${expectedReportPath}`);
@@ -144,6 +31,13 @@ function loadExpectedReport(expectedReportPath: string) {
 
 function createScenarioTest(scenario: Scenario) {
   test(scenario.name, async () => {
+    if (!fs.existsSync(scenario.expectedReportPath)) {
+      throw new Error(
+        `Missing expected report for scenario "${scenario.name}" at ${scenario.expectedReportPath}. ` +
+          'Run "npm run generate-missing-test-reports" to create a draft report (report-generated-to-check.json).'
+      );
+    }
+
     const actualReport = await runScenario(scenario);
     const expectedReport = loadExpectedReport(scenario.expectedReportPath);
 

--- a/analyse/src/tests/data-clumps/scenarioUtils.ts
+++ b/analyse/src/tests/data-clumps/scenarioUtils.ts
@@ -1,0 +1,171 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { Detector, DetectorOptions } from '../../ignoreCoverage/detector/Detector';
+import { ParserHelper } from '../../ignoreCoverage/ParserHelper';
+import { SoftwareProjectDicts } from '../../ignoreCoverage/SoftwareProject';
+import { ParserInterface } from '../../ignoreCoverage/parsers/ParserInterface';
+import { ParserHelperJavaSourceCode } from '../../ignoreCoverage/parsers/ParserHelperJavaSourceCode';
+import { ParserHelperTypeScript } from '../../ignoreCoverage/parsers/ParserHelperTypeScript';
+import { ClassOrInterfaceTypeContext } from '../../ignoreCoverage/ParsedAstTypes';
+
+export interface ScenarioConfig {
+  name: string;
+  language: string;
+  sourceDir: string;
+  expectedReportFile: string;
+  detectorOptions?: Partial<DetectorOptions>;
+}
+
+export interface Scenario extends ScenarioConfig {
+  scenarioDir: string;
+  configPath: string;
+  sourcePath: string;
+  expectedReportPath: string;
+}
+
+type ParserWithDictionary = ParserInterface & {
+  parseSourceToDictOfClassesOrInterfaces: (
+    path: string
+  ) => Promise<Map<string, ClassOrInterfaceTypeContext>>;
+};
+
+function parserSupportsDictionary(parser: ParserInterface): parser is ParserWithDictionary {
+  return typeof (parser as Partial<ParserWithDictionary>).parseSourceToDictOfClassesOrInterfaces === 'function';
+}
+
+function resolveScenarioPaths(configPath: string, rawConfig: ScenarioConfig): Scenario {
+  const scenarioDir = path.dirname(configPath);
+  return {
+    ...rawConfig,
+    scenarioDir,
+    configPath,
+    sourcePath: path.resolve(scenarioDir, rawConfig.sourceDir),
+    expectedReportPath: path.resolve(scenarioDir, rawConfig.expectedReportFile),
+  };
+}
+
+export function discoverScenarioConfigs(baseDir: string): Scenario[] {
+  if (!fs.existsSync(baseDir)) {
+    return [];
+  }
+
+  const stack: string[] = [baseDir];
+  const scenarios: Scenario[] = [];
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (entry.isFile() && entry.name === 'test.config.json') {
+        const rawConfig = JSON.parse(fs.readFileSync(entryPath, 'utf8')) as ScenarioConfig;
+        scenarios.push(resolveScenarioPaths(entryPath, rawConfig));
+      }
+    }
+  }
+
+  return scenarios;
+}
+
+export function resolveTestCasesBaseDir(): { baseDir: string; scenarios: Scenario[] } {
+  const candidates = [
+    path.resolve(__dirname, 'test-cases'),
+    path.resolve(__dirname, '..', '..', '..', 'src/tests/data-clumps/test-cases'),
+  ];
+
+  for (const candidate of candidates) {
+    const scenarios = discoverScenarioConfigs(candidate);
+    if (scenarios.length > 0) {
+      return { baseDir: candidate, scenarios };
+    }
+  }
+
+  const fallback = candidates.find(candidate => fs.existsSync(candidate)) ?? candidates[0];
+  return { baseDir: fallback, scenarios: [] };
+}
+
+function resolveAstGeneratorFolder(): string {
+  const candidates = [
+    path.resolve(__dirname, '../ignoreCoverage/astGenerator'),
+    path.resolve(__dirname, '..', 'ignoreCoverage/astGenerator'),
+    path.resolve(__dirname, '..', '..', '..', 'src/ignoreCoverage/astGenerator'),
+    path.resolve(__dirname, '..', '..', '..', 'ignoreCoverage/astGenerator'),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`Could not find astGenerator folder. Looked in: ${candidates.join(', ')}`);
+}
+
+export function createParser(language: string): ParserInterface {
+  switch (language.toLowerCase()) {
+    case 'typescript':
+      return new ParserHelperTypeScript();
+    case 'java':
+      return new ParserHelperJavaSourceCode(resolveAstGeneratorFolder());
+    default:
+      throw new Error(`Unsupported language: ${language}`);
+  }
+}
+
+async function buildSoftwareProjectDicts(
+  parser: ParserInterface,
+  sourcePath: string,
+  detectorOptions: Partial<DetectorOptions> | undefined
+): Promise<SoftwareProjectDicts> {
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`Source path does not exist: ${sourcePath}`);
+  }
+
+  if (parserSupportsDictionary(parser)) {
+    const classesOrInterfaces = await parser.parseSourceToDictOfClassesOrInterfaces(sourcePath);
+    const softwareProjectDicts = new SoftwareProjectDicts();
+    for (const classOrInterface of classesOrInterfaces.values()) {
+      softwareProjectDicts.loadClassOrInterface(classOrInterface);
+    }
+    return softwareProjectDicts;
+  }
+
+  const tempAstDir = fs.mkdtempSync(path.join(os.tmpdir(), 'data-clumps-ast-'));
+
+  try {
+    await parser.parseSourceToAst(sourcePath, tempAstDir);
+    return await ParserHelper.getSoftwareProjectDictsFromParsedAstFolder(tempAstDir, detectorOptions ?? {});
+  } finally {
+    try {
+      await ParserHelper.removeGeneratedAst(tempAstDir, `Cleanup temporary AST output for ${sourcePath}`);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn(`Failed to remove temporary AST output at ${tempAstDir}:`, error);
+    }
+  }
+}
+
+export async function runScenario(scenario: Scenario) {
+  const parser = createParser(scenario.language);
+  const softwareProjectDicts = await buildSoftwareProjectDicts(parser, scenario.sourcePath, scenario.detectorOptions);
+  const detector = new Detector(
+    softwareProjectDicts,
+    scenario.detectorOptions ?? null,
+    null,
+    null,
+    scenario.name,
+    null,
+    null,
+    null,
+    null,
+    null,
+    scenario.language
+  );
+  return detector.detect();
+}
+

--- a/analyse/src/tests/data-clumps/test-cases/field-field/positive-simple/java/report-expected.json
+++ b/analyse/src/tests/data-clumps/test-cases/field-field/positive-simple/java/report-expected.json
@@ -1,0 +1,283 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-19T17:23:52.607Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToClasses": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 2,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java field-field data clump between Patient and Doctor",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 0,
+    "number_of_data_fields": 6,
+    "number_of_method_parameters": 0
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "fields_to_fields_data_clump-Doctor.java-Doctor-Patient-agelastnamefirstname": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Doctor.java-Doctor-Patient-agelastnamefirstname",
+      "probability": 1,
+      "from_file_path": "Doctor.java",
+      "from_class_or_interface_name": "Doctor",
+      "from_class_or_interface_key": "Doctor",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Patient.java",
+      "to_class_or_interface_key": "Patient",
+      "to_class_or_interface_name": "Doctor",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Doctor/memberField/age": {
+          "key": "Doctor/memberField/age",
+          "name": "age",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient/memberField/age",
+            "name": "age",
+            "type": "int",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 4,
+              "startColumn": 16,
+              "endLine": 4,
+              "endColumn": 19
+            }
+          },
+          "position": {
+            "startLine": 4,
+            "startColumn": 16,
+            "endLine": 4,
+            "endColumn": 19
+          }
+        },
+        "Doctor/memberField/lastname": {
+          "key": "Doctor/memberField/lastname",
+          "name": "lastname",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient/memberField/lastname",
+            "name": "lastname",
+            "type": "java.lang.String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 3,
+              "startColumn": 19,
+              "endLine": 3,
+              "endColumn": 27
+            }
+          },
+          "position": {
+            "startLine": 3,
+            "startColumn": 19,
+            "endLine": 3,
+            "endColumn": 27
+          }
+        },
+        "Doctor/memberField/firstname": {
+          "key": "Doctor/memberField/firstname",
+          "name": "firstname",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient/memberField/firstname",
+            "name": "firstname",
+            "type": "java.lang.String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 2,
+              "startColumn": 19,
+              "endLine": 2,
+              "endColumn": 28
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 19,
+            "endLine": 2,
+            "endColumn": 28
+          }
+        }
+      }
+    },
+    "fields_to_fields_data_clump-Patient.java-Patient-Doctor-lastnameagefirstname": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Patient.java-Patient-Doctor-lastnameagefirstname",
+      "probability": 1,
+      "from_file_path": "Patient.java",
+      "from_class_or_interface_name": "Patient",
+      "from_class_or_interface_key": "Patient",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Doctor.java",
+      "to_class_or_interface_key": "Doctor",
+      "to_class_or_interface_name": "Patient",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Patient/memberField/lastname": {
+          "key": "Patient/memberField/lastname",
+          "name": "lastname",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor/memberField/lastname",
+            "name": "lastname",
+            "type": "java.lang.String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 3,
+              "startColumn": 19,
+              "endLine": 3,
+              "endColumn": 27
+            }
+          },
+          "position": {
+            "startLine": 3,
+            "startColumn": 19,
+            "endLine": 3,
+            "endColumn": 27
+          }
+        },
+        "Patient/memberField/age": {
+          "key": "Patient/memberField/age",
+          "name": "age",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor/memberField/age",
+            "name": "age",
+            "type": "int",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 4,
+              "startColumn": 16,
+              "endLine": 4,
+              "endColumn": 19
+            }
+          },
+          "position": {
+            "startLine": 4,
+            "startColumn": 16,
+            "endLine": 4,
+            "endColumn": 19
+          }
+        },
+        "Patient/memberField/firstname": {
+          "key": "Patient/memberField/firstname",
+          "name": "firstname",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor/memberField/firstname",
+            "name": "firstname",
+            "type": "java.lang.String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 2,
+              "startColumn": 19,
+              "endLine": 2,
+              "endColumn": 28
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 19,
+            "endLine": 2,
+            "endColumn": 28
+          }
+        }
+      }
+    }
+  }
+}

--- a/analyse/src/tests/data-clumps/test-cases/field-field/positive-simple/java/source/Doctor.java
+++ b/analyse/src/tests/data-clumps/test-cases/field-field/positive-simple/java/source/Doctor.java
@@ -1,0 +1,11 @@
+public class Doctor {
+    public String firstname;
+    public String lastname;
+    public int age;
+
+    public Doctor(String firstname, String lastname, int age) {
+        this.firstname = firstname;
+        this.lastname = lastname;
+        this.age = age;
+    }
+}

--- a/analyse/src/tests/data-clumps/test-cases/field-field/positive-simple/java/source/Patient.java
+++ b/analyse/src/tests/data-clumps/test-cases/field-field/positive-simple/java/source/Patient.java
@@ -1,0 +1,11 @@
+public class Patient {
+    public String firstname;
+    public String lastname;
+    public int age;
+
+    public Patient(String firstname, String lastname, int age) {
+        this.firstname = firstname;
+        this.lastname = lastname;
+        this.age = age;
+    }
+}

--- a/analyse/src/tests/data-clumps/test-cases/field-field/positive-simple/java/test.config.json
+++ b/analyse/src/tests/data-clumps/test-cases/field-field/positive-simple/java/test.config.json
@@ -1,0 +1,7 @@
+{
+  "name": "Java field-field data clump between Patient and Doctor",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {}
+}

--- a/analyse/src/tests/generateMissingReports.ts
+++ b/analyse/src/tests/generateMissingReports.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+
+import { resolveTestCasesBaseDir, runScenario, Scenario } from './data-clumps/scenarioUtils';
+
+async function generateReportForScenario(scenario: Scenario) {
+  const report = await runScenario(scenario);
+  const outputPath = path.resolve(scenario.scenarioDir, 'report-generated-to-check.json');
+  fs.writeFileSync(outputPath, JSON.stringify(report, null, 2));
+  console.log(`Generated report for "${scenario.name}" at ${outputPath}`);
+}
+
+async function main() {
+  const { scenarios, baseDir } = resolveTestCasesBaseDir();
+  if (scenarios.length === 0) {
+    console.error(`No scenarios discovered in ${baseDir}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const missingExpected = scenarios.filter(scenario => !fs.existsSync(scenario.expectedReportPath));
+
+  if (missingExpected.length === 0) {
+    console.log('All scenarios already have expected reports. Nothing to generate.');
+    return;
+  }
+
+  for (const scenario of missingExpected) {
+    await generateReportForScenario(scenario);
+  }
+}
+
+void main();
+


### PR DESCRIPTION
## Summary
- extract reusable scenario utilities that support both TypeScript and Java parsing for data-clump tests
- add a Java field-field sample scenario and enforce missing expected reports to fail tests immediately
- provide a helper script and npm command to generate draft reports for scenarios without expectations while keeping jest from executing the helpers

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd8ff656dc8330bd8eff7a68f75a6e