### PR TITLE
Fix CI jobs to run from repository root

### DIFF
--- a/.github/actions/prettier/action.yml
+++ b/.github/actions/prettier/action.yml
@@ -14,6 +14,6 @@ runs:
     - name: Run Prettier
       run: |
         echo "Running Prettier on supported files..."
-        cd analyse && prettier --write "**/*.{js,jsx,ts,tsx,json,md,yml,yaml}" --ignore-path .prettierignore --cache --cache-location .prettier-cache/ || true
+        prettier --write "**/*.{js,jsx,ts,tsx,json,md,yml,yaml}" --ignore-path .prettierignore --cache --cache-location .prettier-cache/ || true
         echo "Prettier formatting completed"
       shell: bash

--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -42,5 +42,5 @@ runs:
         token: ${{ inputs.EXPO_TOKEN }}
 
     - name: 📦 Install dependencies
-      run: cd analyse && yarn install --immutable
+      run: yarn install --immutable
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
         with:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       - name: "🎨 Prettier"
-        run: cd analyse && yarn format
+        run: yarn format
       - name: "✨ ESLint"
-        run: cd analyse && yarn lint
+        run: yarn lint
       - name: "📤 Commit linting changes"
         run: |
           git config user.name "github-actions"
@@ -52,14 +52,12 @@ jobs:
       - name: "📦 Install dependencies"
         run: |
           corepack enable
-          cd analyse
           yarn install --immutable
       - name: "🧪 Run Jest tests"
         run: |
-          cd analyse
-          mkdir -p ../reports/tests
+          mkdir -p reports/tests
           yarn build
-          yarn testOnly --json --outputFile=../reports/tests/jest-results.json --ci --runInBand
+          yarn testOnly --json --outputFile=reports/tests/jest-results.json --ci --runInBand
       - name: "🔢 Extract test case count"
         id: test-count
         run: |


### PR DESCRIPTION
## Summary
- run the lint job's prettier and eslint steps from the repository root
- install dependencies and execute tests for the report job without changing directories
- update shared setup and prettier composite actions to operate at the repository root

## Testing
- not run (workflow configuration changes)


------
https://chatgpt.com/codex/tasks/task_e_68ce5324eb9483309be0ed8f1648b66b