### PR TITLE
Improve data clump test diagnostics

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -87,7 +87,7 @@ export default {
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-  // modulePathIgnorePatterns: [],
+  modulePathIgnorePatterns: ['<rootDir>/build/package\\.json'],
 
   // Activates notifications for test results
   // notify: false,


### PR DESCRIPTION
## Summary
- compare generated and expected data clump reports using stable formatted JSON instead of hashes
- include a focused diff of mismatching reports in test failures for easier debugging
- ignore the generated build/package.json file during Jest module resolution to prevent haste map collisions

## Testing
- yarn test --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ce69a32f288330aa8ea7be50d4e000