### PR TITLE
Update TypeScript scenario report and hash mismatch message

### DIFF
--- a/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/report-expected.json
@@ -1,6 +1,6 @@
 {
   "report_version": "^0.1.102",
-  "report_timestamp": "2025-09-20T08:00:36.124Z",
+  "report_timestamp": "2025-09-20T09:04:06.346Z",
   "target_language": "typescript",
   "report_summary": {
     "additional": {
@@ -90,12 +90,16 @@
           "name": "address",
           "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/Address\").Address",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Patient.ts/class/Patient/memberField/address",
             "name": "address",
             "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/Address\").Address",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -105,12 +109,16 @@
           "name": "contactInfo",
           "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/ContactInfo\").ContactInfo",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Patient.ts/class/Patient/memberField/contactInfo",
             "name": "contactInfo",
             "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/ContactInfo\").ContactInfo",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -120,12 +128,16 @@
           "name": "insurance",
           "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/Insurance\").Insurance",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Patient.ts/class/Patient/memberField/insurance",
             "name": "insurance",
             "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/Insurance\").Insurance",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -153,12 +165,16 @@
           "name": "address",
           "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/Address\").Address",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Doctor.ts/class/Doctor/memberField/address",
             "name": "address",
             "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/Address\").Address",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -168,12 +184,16 @@
           "name": "contactInfo",
           "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/ContactInfo\").ContactInfo",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Doctor.ts/class/Doctor/memberField/contactInfo",
             "name": "contactInfo",
             "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/ContactInfo\").ContactInfo",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -183,12 +203,16 @@
           "name": "insurance",
           "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/Insurance\").Insurance",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Doctor.ts/class/Doctor/memberField/insurance",
             "name": "insurance",
             "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/always-class/positive/typescript/source/Insurance\").Insurance",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}


### PR DESCRIPTION
## Summary
- reduce mismatch logging by comparing SHA-256 hashes when scenario reports differ and allow longer Jest runs
- regenerate the TypeScript field-field always-class expected report after rerunning the detector

## Testing
- npm run testOnly

------
https://chatgpt.com/codex/tasks/task_e_68ce6db2cf3c833081353ca98e01d844