### PR TITLE
Use primitive types in test scenarios

### DIFF
--- a/tests/data-clumps/test-cases/field-field/simple/negative/java/source/Doctor.java
+++ b/tests/data-clumps/test-cases/field-field/simple/negative/java/source/Doctor.java
@@ -1,11 +1,11 @@
 public class Doctor {
-    public String firstName;
-    public String lastName;
-    public String specialization;
+    public int doctorId;
+    public boolean isOnCall;
+    public int appointmentSlots;
 
-    public Doctor(String firstName, String lastName, String specialization) {
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.specialization = specialization;
+    public Doctor(int doctorId, boolean isOnCall, int appointmentSlots) {
+        this.doctorId = doctorId;
+        this.isOnCall = isOnCall;
+        this.appointmentSlots = appointmentSlots;
     }
 }

--- a/tests/data-clumps/test-cases/field-field/simple/negative/java/source/Patient.java
+++ b/tests/data-clumps/test-cases/field-field/simple/negative/java/source/Patient.java
@@ -1,11 +1,11 @@
 public class Patient {
-    public String firstName;
-    public String lastName;
-    public int age;
+    public int patientId;
+    public boolean isActive;
+    public int visitCount;
 
-    public Patient(String firstName, String lastName, int age) {
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.age = age;
+    public Patient(int patientId, boolean isActive, int visitCount) {
+        this.patientId = patientId;
+        this.isActive = isActive;
+        this.visitCount = visitCount;
     }
 }

--- a/tests/data-clumps/test-cases/field-field/simple/negative/typescript/source/Doctor.ts
+++ b/tests/data-clumps/test-cases/field-field/simple/negative/typescript/source/Doctor.ts
@@ -1,11 +1,11 @@
 export class Doctor {
-  public firstName: string;
-  public lastName: string;
-  public specialization: string;
+  public doctorId: number;
+  public isOnCall: boolean;
+  public appointmentSlots: number;
 
-  constructor(firstName: string, lastName: string, specialization: string) {
-    this.firstName = firstName;
-    this.lastName = lastName;
-    this.specialization = specialization;
+  constructor(doctorId: number, isOnCall: boolean, appointmentSlots: number) {
+    this.doctorId = doctorId;
+    this.isOnCall = isOnCall;
+    this.appointmentSlots = appointmentSlots;
   }
 }

--- a/tests/data-clumps/test-cases/field-field/simple/negative/typescript/source/Patient.ts
+++ b/tests/data-clumps/test-cases/field-field/simple/negative/typescript/source/Patient.ts
@@ -1,11 +1,11 @@
 export class Patient {
-  public firstName: string;
-  public lastName: string;
-  public age: number;
+  public patientId: number;
+  public isActive: boolean;
+  public visitCount: number;
 
-  constructor(firstName: string, lastName: string, age: number) {
-    this.firstName = firstName;
-    this.lastName = lastName;
-    this.age = age;
+  constructor(patientId: number, isActive: boolean, visitCount: number) {
+    this.patientId = patientId;
+    this.isActive = isActive;
+    this.visitCount = visitCount;
   }
 }

--- a/tests/data-clumps/test-cases/field-field/simple/positive/java/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/simple/positive/java/report-expected.json
@@ -69,9 +69,9 @@
     }
   },
   "data_clumps": {
-    "fields_to_fields_data_clump-Doctor.java-Doctor-Patient-agelastnamefirstname": {
+    "fields_to_fields_data_clump-Doctor.java-Doctor-Patient-visitCountrecordIdisActive": {
       "type": "data_clump",
-      "key": "fields_to_fields_data_clump-Doctor.java-Doctor-Patient-agelastnamefirstname",
+      "key": "fields_to_fields_data_clump-Doctor.java-Doctor-Patient-visitCountrecordIdisActive",
       "probability": 1,
       "from_file_path": "Doctor.java",
       "from_class_or_interface_name": "Doctor",
@@ -85,86 +85,86 @@
       "to_method_name": null,
       "data_clump_type": "fields_to_fields_data_clump",
       "data_clump_data": {
-        "Doctor/memberField/age": {
-          "key": "Doctor/memberField/age",
-          "name": "age",
+        "Doctor/memberField/recordId": {
+          "key": "Doctor/memberField/recordId",
+          "name": "recordId",
           "type": "int",
           "probability": 1,
           "modifiers": ["PUBLIC"],
           "to_variable": {
-            "key": "Patient/memberField/age",
-            "name": "age",
+            "key": "Patient/memberField/recordId",
+            "name": "recordId",
+            "type": "int",
+            "modifiers": ["PUBLIC"],
+            "position": {
+              "startLine": 2,
+              "startColumn": 16,
+              "endLine": 2,
+              "endColumn": 24
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 16,
+            "endLine": 2,
+            "endColumn": 24
+          }
+        },
+        "Doctor/memberField/isActive": {
+          "key": "Doctor/memberField/isActive",
+          "name": "isActive",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": ["PUBLIC"],
+          "to_variable": {
+            "key": "Patient/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
+            "modifiers": ["PUBLIC"],
+            "position": {
+              "startLine": 3,
+              "startColumn": 20,
+              "endLine": 3,
+              "endColumn": 28
+            }
+          },
+          "position": {
+            "startLine": 3,
+            "startColumn": 20,
+            "endLine": 3,
+            "endColumn": 28
+          }
+        },
+        "Doctor/memberField/visitCount": {
+          "key": "Doctor/memberField/visitCount",
+          "name": "visitCount",
+          "type": "int",
+          "probability": 1,
+          "modifiers": ["PUBLIC"],
+          "to_variable": {
+            "key": "Patient/memberField/visitCount",
+            "name": "visitCount",
             "type": "int",
             "modifiers": ["PUBLIC"],
             "position": {
               "startLine": 4,
               "startColumn": 16,
               "endLine": 4,
-              "endColumn": 19
+              "endColumn": 26
             }
           },
           "position": {
             "startLine": 4,
             "startColumn": 16,
             "endLine": 4,
-            "endColumn": 19
-          }
-        },
-        "Doctor/memberField/lastname": {
-          "key": "Doctor/memberField/lastname",
-          "name": "lastname",
-          "type": "java.lang.String",
-          "probability": 1,
-          "modifiers": ["PUBLIC"],
-          "to_variable": {
-            "key": "Patient/memberField/lastname",
-            "name": "lastname",
-            "type": "java.lang.String",
-            "modifiers": ["PUBLIC"],
-            "position": {
-              "startLine": 3,
-              "startColumn": 19,
-              "endLine": 3,
-              "endColumn": 27
-            }
-          },
-          "position": {
-            "startLine": 3,
-            "startColumn": 19,
-            "endLine": 3,
-            "endColumn": 27
-          }
-        },
-        "Doctor/memberField/firstname": {
-          "key": "Doctor/memberField/firstname",
-          "name": "firstname",
-          "type": "java.lang.String",
-          "probability": 1,
-          "modifiers": ["PUBLIC"],
-          "to_variable": {
-            "key": "Patient/memberField/firstname",
-            "name": "firstname",
-            "type": "java.lang.String",
-            "modifiers": ["PUBLIC"],
-            "position": {
-              "startLine": 2,
-              "startColumn": 19,
-              "endLine": 2,
-              "endColumn": 28
-            }
-          },
-          "position": {
-            "startLine": 2,
-            "startColumn": 19,
-            "endLine": 2,
-            "endColumn": 28
+            "endColumn": 26
           }
         }
       }
     },
-    "fields_to_fields_data_clump-Patient.java-Patient-Doctor-lastnameagefirstname": {
+    "fields_to_fields_data_clump-Patient.java-Patient-Doctor-recordIdvisitCountisActive": {
       "type": "data_clump",
-      "key": "fields_to_fields_data_clump-Patient.java-Patient-Doctor-lastnameagefirstname",
+      "key": "fields_to_fields_data_clump-Patient.java-Patient-Doctor-recordIdvisitCountisActive",
       "probability": 1,
       "from_file_path": "Patient.java",
       "from_class_or_interface_name": "Patient",
@@ -178,79 +178,79 @@
       "to_method_name": null,
       "data_clump_type": "fields_to_fields_data_clump",
       "data_clump_data": {
-        "Patient/memberField/lastname": {
-          "key": "Patient/memberField/lastname",
-          "name": "lastname",
-          "type": "java.lang.String",
-          "probability": 1,
-          "modifiers": ["PUBLIC"],
-          "to_variable": {
-            "key": "Doctor/memberField/lastname",
-            "name": "lastname",
-            "type": "java.lang.String",
-            "modifiers": ["PUBLIC"],
-            "position": {
-              "startLine": 3,
-              "startColumn": 19,
-              "endLine": 3,
-              "endColumn": 27
-            }
-          },
-          "position": {
-            "startLine": 3,
-            "startColumn": 19,
-            "endLine": 3,
-            "endColumn": 27
-          }
-        },
-        "Patient/memberField/age": {
-          "key": "Patient/memberField/age",
-          "name": "age",
+        "Patient/memberField/recordId": {
+          "key": "Patient/memberField/recordId",
+          "name": "recordId",
           "type": "int",
           "probability": 1,
           "modifiers": ["PUBLIC"],
           "to_variable": {
-            "key": "Doctor/memberField/age",
-            "name": "age",
+            "key": "Doctor/memberField/recordId",
+            "name": "recordId",
+            "type": "int",
+            "modifiers": ["PUBLIC"],
+            "position": {
+              "startLine": 2,
+              "startColumn": 16,
+              "endLine": 2,
+              "endColumn": 24
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 16,
+            "endLine": 2,
+            "endColumn": 24
+          }
+        },
+        "Patient/memberField/isActive": {
+          "key": "Patient/memberField/isActive",
+          "name": "isActive",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": ["PUBLIC"],
+          "to_variable": {
+            "key": "Doctor/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
+            "modifiers": ["PUBLIC"],
+            "position": {
+              "startLine": 3,
+              "startColumn": 20,
+              "endLine": 3,
+              "endColumn": 28
+            }
+          },
+          "position": {
+            "startLine": 3,
+            "startColumn": 20,
+            "endLine": 3,
+            "endColumn": 28
+          }
+        },
+        "Patient/memberField/visitCount": {
+          "key": "Patient/memberField/visitCount",
+          "name": "visitCount",
+          "type": "int",
+          "probability": 1,
+          "modifiers": ["PUBLIC"],
+          "to_variable": {
+            "key": "Doctor/memberField/visitCount",
+            "name": "visitCount",
             "type": "int",
             "modifiers": ["PUBLIC"],
             "position": {
               "startLine": 4,
               "startColumn": 16,
               "endLine": 4,
-              "endColumn": 19
+              "endColumn": 26
             }
           },
           "position": {
             "startLine": 4,
             "startColumn": 16,
             "endLine": 4,
-            "endColumn": 19
-          }
-        },
-        "Patient/memberField/firstname": {
-          "key": "Patient/memberField/firstname",
-          "name": "firstname",
-          "type": "java.lang.String",
-          "probability": 1,
-          "modifiers": ["PUBLIC"],
-          "to_variable": {
-            "key": "Doctor/memberField/firstname",
-            "name": "firstname",
-            "type": "java.lang.String",
-            "modifiers": ["PUBLIC"],
-            "position": {
-              "startLine": 2,
-              "startColumn": 19,
-              "endLine": 2,
-              "endColumn": 28
-            }
-          },
-          "position": {
-            "startLine": 2,
-            "startColumn": 19,
-            "endLine": 2,
-            "endColumn": 28
+            "endColumn": 26
           }
         }
       }

--- a/tests/data-clumps/test-cases/field-field/simple/positive/java/source/Doctor.java
+++ b/tests/data-clumps/test-cases/field-field/simple/positive/java/source/Doctor.java
@@ -1,11 +1,11 @@
 public class Doctor {
-    public String firstname;
-    public String lastname;
-    public int age;
+    public int recordId;
+    public boolean isActive;
+    public int visitCount;
 
-    public Doctor(String firstname, String lastname, int age) {
-        this.firstname = firstname;
-        this.lastname = lastname;
-        this.age = age;
+    public Doctor(int recordId, boolean isActive, int visitCount) {
+        this.recordId = recordId;
+        this.isActive = isActive;
+        this.visitCount = visitCount;
     }
 }

--- a/tests/data-clumps/test-cases/field-field/simple/positive/java/source/Patient.java
+++ b/tests/data-clumps/test-cases/field-field/simple/positive/java/source/Patient.java
@@ -1,11 +1,11 @@
 public class Patient {
-    public String firstname;
-    public String lastname;
-    public int age;
+    public int recordId;
+    public boolean isActive;
+    public int visitCount;
 
-    public Patient(String firstname, String lastname, int age) {
-        this.firstname = firstname;
-        this.lastname = lastname;
-        this.age = age;
+    public Patient(int recordId, boolean isActive, int visitCount) {
+        this.recordId = recordId;
+        this.isActive = isActive;
+        this.visitCount = visitCount;
     }
 }

--- a/tests/data-clumps/test-cases/field-field/simple/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/simple/positive/typescript/report-expected.json
@@ -69,9 +69,9 @@
     }
   },
   "data_clumps": {
-    "fields_to_fields_data_clump-Doctor.ts-Doctor.ts/class/Doctor-Patient.ts/class/Patient-firstnamelastnameage": {
+    "fields_to_fields_data_clump-Doctor.ts-Doctor.ts/class/Doctor-Patient.ts/class/Patient-recordIdisActivevisitCount": {
       "type": "data_clump",
-      "key": "fields_to_fields_data_clump-Doctor.ts-Doctor.ts/class/Doctor-Patient.ts/class/Patient-firstnamelastnameage",
+      "key": "fields_to_fields_data_clump-Doctor.ts-Doctor.ts/class/Doctor-Patient.ts/class/Patient-recordIdisActivevisitCount",
       "probability": 1,
       "from_file_path": "Doctor.ts",
       "from_class_or_interface_name": "Doctor",
@@ -85,45 +85,45 @@
       "to_method_name": null,
       "data_clump_type": "fields_to_fields_data_clump",
       "data_clump_data": {
-        "Doctor.ts/class/Doctor/memberField/firstname": {
-          "key": "Doctor.ts/class/Doctor/memberField/firstname",
-          "name": "firstname",
-          "type": "string",
-          "probability": 1,
-          "modifiers": ["PUBLIC"],
-          "to_variable": {
-            "key": "Patient.ts/class/Patient/memberField/firstname",
-            "name": "firstname",
-            "type": "string",
-            "modifiers": ["PUBLIC"],
-            "position": {}
-          },
-          "position": {}
-        },
-        "Doctor.ts/class/Doctor/memberField/lastname": {
-          "key": "Doctor.ts/class/Doctor/memberField/lastname",
-          "name": "lastname",
-          "type": "string",
-          "probability": 1,
-          "modifiers": ["PUBLIC"],
-          "to_variable": {
-            "key": "Patient.ts/class/Patient/memberField/lastname",
-            "name": "lastname",
-            "type": "string",
-            "modifiers": ["PUBLIC"],
-            "position": {}
-          },
-          "position": {}
-        },
-        "Doctor.ts/class/Doctor/memberField/age": {
-          "key": "Doctor.ts/class/Doctor/memberField/age",
-          "name": "age",
+        "Doctor.ts/class/Doctor/memberField/recordId": {
+          "key": "Doctor.ts/class/Doctor/memberField/recordId",
+          "name": "recordId",
           "type": "number",
           "probability": 1,
           "modifiers": ["PUBLIC"],
           "to_variable": {
-            "key": "Patient.ts/class/Patient/memberField/age",
-            "name": "age",
+            "key": "Patient.ts/class/Patient/memberField/recordId",
+            "name": "recordId",
+            "type": "number",
+            "modifiers": ["PUBLIC"],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Doctor.ts/class/Doctor/memberField/isActive": {
+          "key": "Doctor.ts/class/Doctor/memberField/isActive",
+          "name": "isActive",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": ["PUBLIC"],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
+            "modifiers": ["PUBLIC"],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Doctor.ts/class/Doctor/memberField/visitCount": {
+          "key": "Doctor.ts/class/Doctor/memberField/visitCount",
+          "name": "visitCount",
+          "type": "number",
+          "probability": 1,
+          "modifiers": ["PUBLIC"],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/visitCount",
+            "name": "visitCount",
             "type": "number",
             "modifiers": ["PUBLIC"],
             "position": {}
@@ -132,9 +132,9 @@
         }
       }
     },
-    "fields_to_fields_data_clump-Patient.ts-Patient.ts/class/Patient-Doctor.ts/class/Doctor-firstnamelastnameage": {
+    "fields_to_fields_data_clump-Patient.ts-Patient.ts/class/Patient-Doctor.ts/class/Doctor-recordIdisActivevisitCount": {
       "type": "data_clump",
-      "key": "fields_to_fields_data_clump-Patient.ts-Patient.ts/class/Patient-Doctor.ts/class/Doctor-firstnamelastnameage",
+      "key": "fields_to_fields_data_clump-Patient.ts-Patient.ts/class/Patient-Doctor.ts/class/Doctor-recordIdisActivevisitCount",
       "probability": 1,
       "from_file_path": "Patient.ts",
       "from_class_or_interface_name": "Patient",
@@ -148,45 +148,45 @@
       "to_method_name": null,
       "data_clump_type": "fields_to_fields_data_clump",
       "data_clump_data": {
-        "Patient.ts/class/Patient/memberField/firstname": {
-          "key": "Patient.ts/class/Patient/memberField/firstname",
-          "name": "firstname",
-          "type": "string",
-          "probability": 1,
-          "modifiers": ["PUBLIC"],
-          "to_variable": {
-            "key": "Doctor.ts/class/Doctor/memberField/firstname",
-            "name": "firstname",
-            "type": "string",
-            "modifiers": ["PUBLIC"],
-            "position": {}
-          },
-          "position": {}
-        },
-        "Patient.ts/class/Patient/memberField/lastname": {
-          "key": "Patient.ts/class/Patient/memberField/lastname",
-          "name": "lastname",
-          "type": "string",
-          "probability": 1,
-          "modifiers": ["PUBLIC"],
-          "to_variable": {
-            "key": "Doctor.ts/class/Doctor/memberField/lastname",
-            "name": "lastname",
-            "type": "string",
-            "modifiers": ["PUBLIC"],
-            "position": {}
-          },
-          "position": {}
-        },
-        "Patient.ts/class/Patient/memberField/age": {
-          "key": "Patient.ts/class/Patient/memberField/age",
-          "name": "age",
+        "Patient.ts/class/Patient/memberField/recordId": {
+          "key": "Patient.ts/class/Patient/memberField/recordId",
+          "name": "recordId",
           "type": "number",
           "probability": 1,
           "modifiers": ["PUBLIC"],
           "to_variable": {
-            "key": "Doctor.ts/class/Doctor/memberField/age",
-            "name": "age",
+            "key": "Doctor.ts/class/Doctor/memberField/recordId",
+            "name": "recordId",
+            "type": "number",
+            "modifiers": ["PUBLIC"],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Patient.ts/class/Patient/memberField/isActive": {
+          "key": "Patient.ts/class/Patient/memberField/isActive",
+          "name": "isActive",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": ["PUBLIC"],
+          "to_variable": {
+            "key": "Doctor.ts/class/Doctor/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
+            "modifiers": ["PUBLIC"],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Patient.ts/class/Patient/memberField/visitCount": {
+          "key": "Patient.ts/class/Patient/memberField/visitCount",
+          "name": "visitCount",
+          "type": "number",
+          "probability": 1,
+          "modifiers": ["PUBLIC"],
+          "to_variable": {
+            "key": "Doctor.ts/class/Doctor/memberField/visitCount",
+            "name": "visitCount",
             "type": "number",
             "modifiers": ["PUBLIC"],
             "position": {}

--- a/tests/data-clumps/test-cases/field-field/simple/positive/typescript/source/Doctor.ts
+++ b/tests/data-clumps/test-cases/field-field/simple/positive/typescript/source/Doctor.ts
@@ -1,11 +1,11 @@
 export class Doctor {
-  public firstname: string;
-  public lastname: string;
-  public age: number;
+  public recordId: number;
+  public isActive: boolean;
+  public visitCount: number;
 
-  constructor(firstname: string, lastname: string, age: number) {
-    this.firstname = firstname;
-    this.lastname = lastname;
-    this.age = age;
+  constructor(recordId: number, isActive: boolean, visitCount: number) {
+    this.recordId = recordId;
+    this.isActive = isActive;
+    this.visitCount = visitCount;
   }
 }

--- a/tests/data-clumps/test-cases/field-field/simple/positive/typescript/source/Patient.ts
+++ b/tests/data-clumps/test-cases/field-field/simple/positive/typescript/source/Patient.ts
@@ -1,11 +1,11 @@
 export class Patient {
-  public firstname: string;
-  public lastname: string;
-  public age: number;
+  public recordId: number;
+  public isActive: boolean;
+  public visitCount: number;
 
-  constructor(firstname: string, lastname: string, age: number) {
-    this.firstname = firstname;
-    this.lastname = lastname;
-    this.age = age;
+  constructor(recordId: number, isActive: boolean, visitCount: number) {
+    this.recordId = recordId;
+    this.isActive = isActive;
+    this.visitCount = visitCount;
   }
 }

--- a/tests/data-clumps/test-cases/parameter-field/simple/negative/java/source/Patient.java
+++ b/tests/data-clumps/test-cases/parameter-field/simple/negative/java/source/Patient.java
@@ -1,11 +1,11 @@
 public class Patient {
-    public String firstName;
-    public String lastName;
-    public String insuranceNumber;
+    public int patientId;
+    public boolean isActive;
+    public int visitCount;
 
-    public Patient(String firstName, String lastName, String insuranceNumber) {
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.insuranceNumber = insuranceNumber;
+    public Patient(int patientId, boolean isActive, int visitCount) {
+        this.patientId = patientId;
+        this.isActive = isActive;
+        this.visitCount = visitCount;
     }
 }

--- a/tests/data-clumps/test-cases/parameter-field/simple/negative/java/source/PatientService.java
+++ b/tests/data-clumps/test-cases/parameter-field/simple/negative/java/source/PatientService.java
@@ -1,5 +1,6 @@
 public class PatientService {
-    public void updateContact(String firstName, String lastName, String email) {
-        System.out.println("Updating contact details for " + firstName + " " + lastName + " with email " + email);
+    public void updateContact(int patientId, boolean isActive, int contactCode) {
+        System.out.println(
+                "Updating contact details for patient " + patientId + " (active: " + isActive + ") with contact code " + contactCode);
     }
 }

--- a/tests/data-clumps/test-cases/parameter-field/simple/negative/typescript/source/Patient.ts
+++ b/tests/data-clumps/test-cases/parameter-field/simple/negative/typescript/source/Patient.ts
@@ -1,11 +1,11 @@
 export class Patient {
-  public firstName: string;
-  public lastName: string;
-  public insuranceNumber: string;
+  public patientId: number;
+  public isActive: boolean;
+  public visitCount: number;
 
-  constructor(firstName: string, lastName: string, insuranceNumber: string) {
-    this.firstName = firstName;
-    this.lastName = lastName;
-    this.insuranceNumber = insuranceNumber;
+  constructor(patientId: number, isActive: boolean, visitCount: number) {
+    this.patientId = patientId;
+    this.isActive = isActive;
+    this.visitCount = visitCount;
   }
 }

--- a/tests/data-clumps/test-cases/parameter-field/simple/negative/typescript/source/PatientService.ts
+++ b/tests/data-clumps/test-cases/parameter-field/simple/negative/typescript/source/PatientService.ts
@@ -1,5 +1,7 @@
 export class PatientService {
-  updateContact(firstName: string, lastName: string, email: string): void {
-    console.log(`Updating contact details for ${firstName} ${lastName} with email ${email}`);
+  updateContact(patientId: number, isActive: boolean, contactCode: number): void {
+    console.log(
+      `Updating contact details for patient ${patientId} (active: ${isActive}) with contact code ${contactCode}`
+    );
   }
 }

--- a/tests/data-clumps/test-cases/parameter-field/simple/positive/java/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple/positive/java/report-expected.json
@@ -69,15 +69,15 @@
     }
   },
   "data_clumps": {
-    "parameters_to_fields_data_clump-PatientService.java-PatientService/method/registerPatient(java.lang.String firstName, java.lang.String lastName, java.lang.String insuranceNumber)-Patient-firstNamelastNameinsuranceNumber": {
+    "parameters_to_fields_data_clump-PatientService.java-PatientService/method/registerPatient(int recordId, boolean isActive, int visitCount)-Patient-recordIdisActivevisitCount": {
       "type": "data_clump",
-      "key": "parameters_to_fields_data_clump-PatientService.java-PatientService/method/registerPatient(java.lang.String firstName, java.lang.String lastName, java.lang.String insuranceNumber)-Patient-firstNamelastNameinsuranceNumber",
+      "key": "parameters_to_fields_data_clump-PatientService.java-PatientService/method/registerPatient(int recordId, boolean isActive, int visitCount)-Patient-recordIdisActivevisitCount",
       "probability": 1,
       "from_file_path": "PatientService.java",
       "from_class_or_interface_name": "PatientService",
       "from_class_or_interface_key": "PatientService",
       "from_method_name": "registerPatient",
-      "from_method_key": "PatientService/method/registerPatient(java.lang.String firstName, java.lang.String lastName, java.lang.String insuranceNumber)",
+      "from_method_key": "PatientService/method/registerPatient(int recordId, boolean isActive, int visitCount)",
       "to_file_path": "Patient.java",
       "to_class_or_interface_name": "Patient",
       "to_class_or_interface_key": "Patient",
@@ -85,79 +85,79 @@
       "to_method_key": null,
       "data_clump_type": "parameters_to_fields_data_clump",
       "data_clump_data": {
-        "PatientService/method/registerPatient(java.lang.String firstName, java.lang.String lastName, java.lang.String insuranceNumber)/parameter/firstName": {
-          "key": "PatientService/method/registerPatient(java.lang.String firstName, java.lang.String lastName, java.lang.String insuranceNumber)/parameter/firstName",
-          "name": "firstName",
-          "type": "java.lang.String",
+        "PatientService/method/registerPatient(int recordId, boolean isActive, int visitCount)/parameter/recordId": {
+          "key": "PatientService/method/registerPatient(int recordId, boolean isActive, int visitCount)/parameter/recordId",
+          "name": "recordId",
+          "type": "int",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
-            "key": "Patient/memberField/firstName",
-            "name": "firstName",
-            "type": "java.lang.String",
+            "key": "Patient/memberField/recordId",
+            "name": "recordId",
+            "type": "int",
             "modifiers": ["PUBLIC"],
             "position": {
               "startLine": 2,
-              "startColumn": 19,
+              "startColumn": 16,
               "endLine": 2,
+              "endColumn": 24
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 37,
+            "endLine": 2,
+            "endColumn": 45
+          }
+        },
+        "PatientService/method/registerPatient(int recordId, boolean isActive, int visitCount)/parameter/isActive": {
+          "key": "PatientService/method/registerPatient(int recordId, boolean isActive, int visitCount)/parameter/isActive",
+          "name": "isActive",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "Patient/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
+            "modifiers": ["PUBLIC"],
+            "position": {
+              "startLine": 3,
+              "startColumn": 20,
+              "endLine": 3,
               "endColumn": 28
             }
           },
           "position": {
             "startLine": 2,
-            "startColumn": 40,
+            "startColumn": 55,
             "endLine": 2,
-            "endColumn": 49
+            "endColumn": 63
           }
         },
-        "PatientService/method/registerPatient(java.lang.String firstName, java.lang.String lastName, java.lang.String insuranceNumber)/parameter/lastName": {
-          "key": "PatientService/method/registerPatient(java.lang.String firstName, java.lang.String lastName, java.lang.String insuranceNumber)/parameter/lastName",
-          "name": "lastName",
-          "type": "java.lang.String",
+        "PatientService/method/registerPatient(int recordId, boolean isActive, int visitCount)/parameter/visitCount": {
+          "key": "PatientService/method/registerPatient(int recordId, boolean isActive, int visitCount)/parameter/visitCount",
+          "name": "visitCount",
+          "type": "int",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
-            "key": "Patient/memberField/lastName",
-            "name": "lastName",
-            "type": "java.lang.String",
-            "modifiers": ["PUBLIC"],
-            "position": {
-              "startLine": 3,
-              "startColumn": 19,
-              "endLine": 3,
-              "endColumn": 27
-            }
-          },
-          "position": {
-            "startLine": 2,
-            "startColumn": 58,
-            "endLine": 2,
-            "endColumn": 66
-          }
-        },
-        "PatientService/method/registerPatient(java.lang.String firstName, java.lang.String lastName, java.lang.String insuranceNumber)/parameter/insuranceNumber": {
-          "key": "PatientService/method/registerPatient(java.lang.String firstName, java.lang.String lastName, java.lang.String insuranceNumber)/parameter/insuranceNumber",
-          "name": "insuranceNumber",
-          "type": "java.lang.String",
-          "probability": 1,
-          "modifiers": [],
-          "to_variable": {
-            "key": "Patient/memberField/insuranceNumber",
-            "name": "insuranceNumber",
-            "type": "java.lang.String",
+            "key": "Patient/memberField/visitCount",
+            "name": "visitCount",
+            "type": "int",
             "modifiers": ["PUBLIC"],
             "position": {
               "startLine": 4,
-              "startColumn": 19,
+              "startColumn": 16,
               "endLine": 4,
-              "endColumn": 34
+              "endColumn": 26
             }
           },
           "position": {
             "startLine": 2,
-            "startColumn": 75,
+            "startColumn": 69,
             "endLine": 2,
-            "endColumn": 90
+            "endColumn": 79
           }
         }
       }

--- a/tests/data-clumps/test-cases/parameter-field/simple/positive/java/source/Patient.java
+++ b/tests/data-clumps/test-cases/parameter-field/simple/positive/java/source/Patient.java
@@ -1,11 +1,11 @@
 public class Patient {
-    public String firstName;
-    public String lastName;
-    public String insuranceNumber;
+    public int recordId;
+    public boolean isActive;
+    public int visitCount;
 
-    public Patient(String firstName, String lastName, String insuranceNumber) {
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.insuranceNumber = insuranceNumber;
+    public Patient(int recordId, boolean isActive, int visitCount) {
+        this.recordId = recordId;
+        this.isActive = isActive;
+        this.visitCount = visitCount;
     }
 }

--- a/tests/data-clumps/test-cases/parameter-field/simple/positive/java/source/PatientService.java
+++ b/tests/data-clumps/test-cases/parameter-field/simple/positive/java/source/PatientService.java
@@ -1,5 +1,6 @@
 public class PatientService {
-    public void registerPatient(String firstName, String lastName, String insuranceNumber) {
-        System.out.println("Registering patient " + firstName + " " + lastName + " with insurance " + insuranceNumber);
+    public void registerPatient(int recordId, boolean isActive, int visitCount) {
+        System.out.println(
+                "Registering patient " + recordId + " with active status " + isActive + " and " + visitCount + " recorded visits");
     }
 }

--- a/tests/data-clumps/test-cases/parameter-field/simple/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple/positive/typescript/report-expected.json
@@ -69,9 +69,9 @@
     }
   },
   "data_clumps": {
-    "parameters_to_fields_data_clump-PatientService.ts-PatientService.ts/class/PatientService/method/registerPatient-Patient.ts/class/Patient-firstNamelastNameinsuranceNumber": {
+    "parameters_to_fields_data_clump-PatientService.ts-PatientService.ts/class/PatientService/method/registerPatient-Patient.ts/class/Patient-recordIdisActivevisitCount": {
       "type": "data_clump",
-      "key": "parameters_to_fields_data_clump-PatientService.ts-PatientService.ts/class/PatientService/method/registerPatient-Patient.ts/class/Patient-firstNamelastNameinsuranceNumber",
+      "key": "parameters_to_fields_data_clump-PatientService.ts-PatientService.ts/class/PatientService/method/registerPatient-Patient.ts/class/Patient-recordIdisActivevisitCount",
       "probability": 1,
       "from_file_path": "PatientService.ts",
       "from_class_or_interface_name": "PatientService",
@@ -85,46 +85,46 @@
       "to_method_key": null,
       "data_clump_type": "parameters_to_fields_data_clump",
       "data_clump_data": {
-        "PatientService.ts/class/PatientService/method/registerPatient/parameter/firstName": {
-          "key": "PatientService.ts/class/PatientService/method/registerPatient/parameter/firstName",
-          "name": "firstName",
-          "type": "string",
+        "PatientService.ts/class/PatientService/method/registerPatient/parameter/recordId": {
+          "key": "PatientService.ts/class/PatientService/method/registerPatient/parameter/recordId",
+          "name": "recordId",
+          "type": "number",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
-            "key": "Patient.ts/class/Patient/memberField/firstName",
-            "name": "firstName",
-            "type": "string",
+            "key": "Patient.ts/class/Patient/memberField/recordId",
+            "name": "recordId",
+            "type": "number",
             "modifiers": ["PUBLIC"],
             "position": {}
           },
           "position": {}
         },
-        "PatientService.ts/class/PatientService/method/registerPatient/parameter/lastName": {
-          "key": "PatientService.ts/class/PatientService/method/registerPatient/parameter/lastName",
-          "name": "lastName",
-          "type": "string",
+        "PatientService.ts/class/PatientService/method/registerPatient/parameter/isActive": {
+          "key": "PatientService.ts/class/PatientService/method/registerPatient/parameter/isActive",
+          "name": "isActive",
+          "type": "boolean",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
-            "key": "Patient.ts/class/Patient/memberField/lastName",
-            "name": "lastName",
-            "type": "string",
+            "key": "Patient.ts/class/Patient/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
             "modifiers": ["PUBLIC"],
             "position": {}
           },
           "position": {}
         },
-        "PatientService.ts/class/PatientService/method/registerPatient/parameter/insuranceNumber": {
-          "key": "PatientService.ts/class/PatientService/method/registerPatient/parameter/insuranceNumber",
-          "name": "insuranceNumber",
-          "type": "string",
+        "PatientService.ts/class/PatientService/method/registerPatient/parameter/visitCount": {
+          "key": "PatientService.ts/class/PatientService/method/registerPatient/parameter/visitCount",
+          "name": "visitCount",
+          "type": "number",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
-            "key": "Patient.ts/class/Patient/memberField/insuranceNumber",
-            "name": "insuranceNumber",
-            "type": "string",
+            "key": "Patient.ts/class/Patient/memberField/visitCount",
+            "name": "visitCount",
+            "type": "number",
             "modifiers": ["PUBLIC"],
             "position": {}
           },

--- a/tests/data-clumps/test-cases/parameter-field/simple/positive/typescript/source/Patient.ts
+++ b/tests/data-clumps/test-cases/parameter-field/simple/positive/typescript/source/Patient.ts
@@ -1,11 +1,11 @@
 export class Patient {
-  public firstName: string;
-  public lastName: string;
-  public insuranceNumber: string;
+  public recordId: number;
+  public isActive: boolean;
+  public visitCount: number;
 
-  constructor(firstName: string, lastName: string, insuranceNumber: string) {
-    this.firstName = firstName;
-    this.lastName = lastName;
-    this.insuranceNumber = insuranceNumber;
+  constructor(recordId: number, isActive: boolean, visitCount: number) {
+    this.recordId = recordId;
+    this.isActive = isActive;
+    this.visitCount = visitCount;
   }
 }

--- a/tests/data-clumps/test-cases/parameter-field/simple/positive/typescript/source/PatientService.ts
+++ b/tests/data-clumps/test-cases/parameter-field/simple/positive/typescript/source/PatientService.ts
@@ -1,5 +1,7 @@
 export class PatientService {
-  registerPatient(firstName: string, lastName: string, insuranceNumber: string): void {
-    console.log(`Registering patient ${firstName} ${lastName} with insurance ${insuranceNumber}`);
+  registerPatient(recordId: number, isActive: boolean, visitCount: number): void {
+    console.log(
+      `Registering patient ${recordId} with active status ${isActive} and ${visitCount} recorded visits`
+    );
   }
 }

--- a/tests/data-clumps/test-cases/parameter-parameter/simple/negative/java/source/AppointmentScheduler.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple/negative/java/source/AppointmentScheduler.java
@@ -1,5 +1,6 @@
 public class AppointmentScheduler {
-    public void schedule(String patientId, String doctorId, String appointmentDate) {
-        System.out.println("Scheduling appointment on " + appointmentDate);
+    public void schedule(int patientId, int doctorId, boolean requiresFollowUp) {
+        System.out.println("Scheduling appointment for patient " + patientId + " with doctor " + doctorId
+                + " (requires follow-up: " + requiresFollowUp + ")");
     }
 }

--- a/tests/data-clumps/test-cases/parameter-parameter/simple/negative/java/source/BillingProcessor.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple/negative/java/source/BillingProcessor.java
@@ -1,5 +1,5 @@
 public class BillingProcessor {
-    public void createInvoice(String patientId, String doctorId, double amount) {
-        System.out.println("Creating invoice of " + amount + " for " + patientId);
+    public void createInvoice(int patientId, int doctorId, double invoiceAmount) {
+        System.out.println("Creating invoice of " + invoiceAmount + " for patient " + patientId + " with doctor " + doctorId);
     }
 }

--- a/tests/data-clumps/test-cases/parameter-parameter/simple/negative/typescript/source/AppointmentScheduler.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple/negative/typescript/source/AppointmentScheduler.ts
@@ -1,5 +1,7 @@
 export class AppointmentScheduler {
-  schedule(patientId: string, doctorId: string, appointmentDate: string): void {
-    console.log(`Scheduling appointment on ${appointmentDate}`);
+  schedule(patientId: number, doctorId: number, requiresFollowUp: boolean): void {
+    console.log(
+      `Scheduling appointment for patient ${patientId} with doctor ${doctorId} (requires follow-up: ${requiresFollowUp})`
+    );
   }
 }

--- a/tests/data-clumps/test-cases/parameter-parameter/simple/negative/typescript/source/BillingProcessor.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple/negative/typescript/source/BillingProcessor.ts
@@ -1,5 +1,5 @@
 export class BillingProcessor {
-  createInvoice(patientId: string, doctorId: string, amount: number): void {
-    console.log(`Creating invoice of ${amount} for ${patientId}`);
+  createInvoice(patientId: number, doctorId: number, invoiceAmount: number): void {
+    console.log(`Creating invoice of ${invoiceAmount} for patient ${patientId} with doctor ${doctorId}`);
   }
 }

--- a/tests/data-clumps/test-cases/parameter-parameter/simple/positive/java/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple/positive/java/report-expected.json
@@ -69,188 +69,188 @@
     }
   },
   "data_clumps": {
-    "parameters_to_parameters_data_clump-AppointmentScheduler.java-AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)-BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)-patientIddoctorIdroomNumber": {
+    "parameters_to_parameters_data_clump-AppointmentScheduler.java-AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)-BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)-patientIddoctorIdrequiresFollowUp": {
       "type": "data_clump",
-      "key": "parameters_to_parameters_data_clump-AppointmentScheduler.java-AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)-BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)-patientIddoctorIdroomNumber",
+      "key": "parameters_to_parameters_data_clump-AppointmentScheduler.java-AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)-BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)-patientIddoctorIdrequiresFollowUp",
       "probability": 1,
       "from_file_path": "AppointmentScheduler.java",
       "from_class_or_interface_name": "AppointmentScheduler",
       "from_class_or_interface_key": "AppointmentScheduler",
       "from_method_name": "schedule",
-      "from_method_key": "AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)",
+      "from_method_key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)",
       "to_file_path": "BillingProcessor.java",
       "to_class_or_interface_name": "BillingProcessor",
       "to_class_or_interface_key": "BillingProcessor",
       "to_method_name": "createInvoice",
-      "to_method_key": "BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)",
+      "to_method_key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)",
       "data_clump_type": "parameters_to_parameters_data_clump",
       "data_clump_data": {
-        "AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/patientId": {
-          "key": "AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/patientId",
+        "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId": {
+          "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId",
           "name": "patientId",
-          "type": "java.lang.String",
+          "type": "int",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
-            "key": "BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/patientId",
+            "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId",
             "name": "patientId",
-            "type": "java.lang.String",
+            "type": "int",
             "modifiers": [],
             "position": {
               "startLine": 2,
-              "startColumn": 38,
+              "startColumn": 35,
               "endLine": 2,
-              "endColumn": 47
+              "endColumn": 44
             }
           },
           "position": {
             "startLine": 2,
-            "startColumn": 33,
+            "startColumn": 30,
             "endLine": 2,
-            "endColumn": 42
+            "endColumn": 39
           }
         },
-        "AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/doctorId": {
-          "key": "AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/doctorId",
+        "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId": {
+          "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId",
           "name": "doctorId",
-          "type": "java.lang.String",
+          "type": "int",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
-            "key": "BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/doctorId",
+            "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId",
             "name": "doctorId",
-            "type": "java.lang.String",
+            "type": "int",
             "modifiers": [],
             "position": {
               "startLine": 2,
-              "startColumn": 56,
+              "startColumn": 50,
               "endLine": 2,
-              "endColumn": 64
+              "endColumn": 58
             }
           },
           "position": {
             "startLine": 2,
-            "startColumn": 51,
+            "startColumn": 45,
             "endLine": 2,
-            "endColumn": 59
+            "endColumn": 53
           }
         },
-        "AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/roomNumber": {
-          "key": "AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/roomNumber",
-          "name": "roomNumber",
-          "type": "java.lang.String",
+        "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp": {
+          "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp",
+          "name": "requiresFollowUp",
+          "type": "boolean",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
-            "key": "BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/roomNumber",
-            "name": "roomNumber",
-            "type": "java.lang.String",
+            "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp",
+            "name": "requiresFollowUp",
+            "type": "boolean",
             "modifiers": [],
             "position": {
               "startLine": 2,
-              "startColumn": 73,
+              "startColumn": 68,
               "endLine": 2,
-              "endColumn": 83
+              "endColumn": 84
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 63,
+            "endLine": 2,
+            "endColumn": 79
+          }
+        }
+      }
+    },
+    "parameters_to_parameters_data_clump-BillingProcessor.java-BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)-AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)-patientIddoctorIdrequiresFollowUp": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-BillingProcessor.java-BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)-AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)-patientIddoctorIdrequiresFollowUp",
+      "probability": 1,
+      "from_file_path": "BillingProcessor.java",
+      "from_class_or_interface_name": "BillingProcessor",
+      "from_class_or_interface_key": "BillingProcessor",
+      "from_method_name": "createInvoice",
+      "from_method_key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)",
+      "to_file_path": "AppointmentScheduler.java",
+      "to_class_or_interface_name": "AppointmentScheduler",
+      "to_class_or_interface_key": "AppointmentScheduler",
+      "to_method_name": "schedule",
+      "to_method_key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId": {
+          "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId",
+          "name": "patientId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId",
+            "name": "patientId",
+            "type": "int",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 30,
+              "endLine": 2,
+              "endColumn": 39
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 35,
+            "endLine": 2,
+            "endColumn": 44
+          }
+        },
+        "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId": {
+          "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId",
+          "name": "doctorId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId",
+            "name": "doctorId",
+            "type": "int",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 45,
+              "endLine": 2,
+              "endColumn": 53
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 50,
+            "endLine": 2,
+            "endColumn": 58
+          }
+        },
+        "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp": {
+          "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp",
+          "name": "requiresFollowUp",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp",
+            "name": "requiresFollowUp",
+            "type": "boolean",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 63,
+              "endLine": 2,
+              "endColumn": 79
             }
           },
           "position": {
             "startLine": 2,
             "startColumn": 68,
             "endLine": 2,
-            "endColumn": 78
-          }
-        }
-      }
-    },
-    "parameters_to_parameters_data_clump-BillingProcessor.java-BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)-AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)-patientIddoctorIdroomNumber": {
-      "type": "data_clump",
-      "key": "parameters_to_parameters_data_clump-BillingProcessor.java-BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)-AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)-patientIddoctorIdroomNumber",
-      "probability": 1,
-      "from_file_path": "BillingProcessor.java",
-      "from_class_or_interface_name": "BillingProcessor",
-      "from_class_or_interface_key": "BillingProcessor",
-      "from_method_name": "createInvoice",
-      "from_method_key": "BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)",
-      "to_file_path": "AppointmentScheduler.java",
-      "to_class_or_interface_name": "AppointmentScheduler",
-      "to_class_or_interface_key": "AppointmentScheduler",
-      "to_method_name": "schedule",
-      "to_method_key": "AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)",
-      "data_clump_type": "parameters_to_parameters_data_clump",
-      "data_clump_data": {
-        "BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/patientId": {
-          "key": "BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/patientId",
-          "name": "patientId",
-          "type": "java.lang.String",
-          "probability": 1,
-          "modifiers": [],
-          "to_variable": {
-            "key": "AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/patientId",
-            "name": "patientId",
-            "type": "java.lang.String",
-            "modifiers": [],
-            "position": {
-              "startLine": 2,
-              "startColumn": 33,
-              "endLine": 2,
-              "endColumn": 42
-            }
-          },
-          "position": {
-            "startLine": 2,
-            "startColumn": 38,
-            "endLine": 2,
-            "endColumn": 47
-          }
-        },
-        "BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/doctorId": {
-          "key": "BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/doctorId",
-          "name": "doctorId",
-          "type": "java.lang.String",
-          "probability": 1,
-          "modifiers": [],
-          "to_variable": {
-            "key": "AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/doctorId",
-            "name": "doctorId",
-            "type": "java.lang.String",
-            "modifiers": [],
-            "position": {
-              "startLine": 2,
-              "startColumn": 51,
-              "endLine": 2,
-              "endColumn": 59
-            }
-          },
-          "position": {
-            "startLine": 2,
-            "startColumn": 56,
-            "endLine": 2,
-            "endColumn": 64
-          }
-        },
-        "BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/roomNumber": {
-          "key": "BillingProcessor/method/createInvoice(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/roomNumber",
-          "name": "roomNumber",
-          "type": "java.lang.String",
-          "probability": 1,
-          "modifiers": [],
-          "to_variable": {
-            "key": "AppointmentScheduler/method/schedule(java.lang.String patientId, java.lang.String doctorId, java.lang.String roomNumber)/parameter/roomNumber",
-            "name": "roomNumber",
-            "type": "java.lang.String",
-            "modifiers": [],
-            "position": {
-              "startLine": 2,
-              "startColumn": 68,
-              "endLine": 2,
-              "endColumn": 78
-            }
-          },
-          "position": {
-            "startLine": 2,
-            "startColumn": 73,
-            "endLine": 2,
-            "endColumn": 83
+            "endColumn": 84
           }
         }
       }

--- a/tests/data-clumps/test-cases/parameter-parameter/simple/positive/java/source/AppointmentScheduler.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple/positive/java/source/AppointmentScheduler.java
@@ -1,5 +1,6 @@
 public class AppointmentScheduler {
-    public void schedule(String patientId, String doctorId, String roomNumber) {
-        System.out.println("Scheduling appointment for " + patientId + " with " + doctorId + " in room " + roomNumber);
+    public void schedule(int patientId, int doctorId, boolean requiresFollowUp) {
+        System.out.println("Scheduling appointment for patient " + patientId + " with doctor " + doctorId
+                + " (requires follow-up: " + requiresFollowUp + ")");
     }
 }

--- a/tests/data-clumps/test-cases/parameter-parameter/simple/positive/java/source/BillingProcessor.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple/positive/java/source/BillingProcessor.java
@@ -1,5 +1,6 @@
 public class BillingProcessor {
-    public void createInvoice(String patientId, String doctorId, String roomNumber) {
-        System.out.println("Creating invoice for " + patientId + " and doctor " + doctorId + " in room " + roomNumber);
+    public void createInvoice(int patientId, int doctorId, boolean requiresFollowUp) {
+        System.out.println("Creating invoice for patient " + patientId + " and doctor " + doctorId
+                + " (requires follow-up: " + requiresFollowUp + ")");
     }
 }

--- a/tests/data-clumps/test-cases/parameter-parameter/simple/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple/positive/typescript/report-expected.json
@@ -69,9 +69,9 @@
     }
   },
   "data_clumps": {
-    "parameters_to_parameters_data_clump-AppointmentScheduler.ts-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-patientIddoctorIdroomNumber": {
+    "parameters_to_parameters_data_clump-AppointmentScheduler.ts-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-patientIddoctorIdrequiresFollowUp": {
       "type": "data_clump",
-      "key": "parameters_to_parameters_data_clump-AppointmentScheduler.ts-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-patientIddoctorIdroomNumber",
+      "key": "parameters_to_parameters_data_clump-AppointmentScheduler.ts-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-patientIddoctorIdrequiresFollowUp",
       "probability": 1,
       "from_file_path": "AppointmentScheduler.ts",
       "from_class_or_interface_name": "AppointmentScheduler",
@@ -88,13 +88,13 @@
         "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/patientId": {
           "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/patientId",
           "name": "patientId",
-          "type": "string",
+          "type": "number",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
             "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/patientId",
             "name": "patientId",
-            "type": "string",
+            "type": "number",
             "modifiers": [],
             "position": {}
           },
@@ -103,28 +103,28 @@
         "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/doctorId": {
           "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/doctorId",
           "name": "doctorId",
-          "type": "string",
+          "type": "number",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
             "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/doctorId",
             "name": "doctorId",
-            "type": "string",
+            "type": "number",
             "modifiers": [],
             "position": {}
           },
           "position": {}
         },
-        "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/roomNumber": {
-          "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/roomNumber",
-          "name": "roomNumber",
-          "type": "string",
+        "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/requiresFollowUp": {
+          "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/requiresFollowUp",
+          "name": "requiresFollowUp",
+          "type": "boolean",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
-            "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/roomNumber",
-            "name": "roomNumber",
-            "type": "string",
+            "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/requiresFollowUp",
+            "name": "requiresFollowUp",
+            "type": "boolean",
             "modifiers": [],
             "position": {}
           },
@@ -132,9 +132,9 @@
         }
       }
     },
-    "parameters_to_parameters_data_clump-BillingProcessor.ts-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-patientIddoctorIdroomNumber": {
+    "parameters_to_parameters_data_clump-BillingProcessor.ts-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-patientIddoctorIdrequiresFollowUp": {
       "type": "data_clump",
-      "key": "parameters_to_parameters_data_clump-BillingProcessor.ts-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-patientIddoctorIdroomNumber",
+      "key": "parameters_to_parameters_data_clump-BillingProcessor.ts-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-patientIddoctorIdrequiresFollowUp",
       "probability": 1,
       "from_file_path": "BillingProcessor.ts",
       "from_class_or_interface_name": "BillingProcessor",
@@ -151,13 +151,13 @@
         "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/patientId": {
           "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/patientId",
           "name": "patientId",
-          "type": "string",
+          "type": "number",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
             "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/patientId",
             "name": "patientId",
-            "type": "string",
+            "type": "number",
             "modifiers": [],
             "position": {}
           },
@@ -166,28 +166,28 @@
         "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/doctorId": {
           "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/doctorId",
           "name": "doctorId",
-          "type": "string",
+          "type": "number",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
             "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/doctorId",
             "name": "doctorId",
-            "type": "string",
+            "type": "number",
             "modifiers": [],
             "position": {}
           },
           "position": {}
         },
-        "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/roomNumber": {
-          "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/roomNumber",
-          "name": "roomNumber",
-          "type": "string",
+        "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/requiresFollowUp": {
+          "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/requiresFollowUp",
+          "name": "requiresFollowUp",
+          "type": "boolean",
           "probability": 1,
           "modifiers": [],
           "to_variable": {
-            "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/roomNumber",
-            "name": "roomNumber",
-            "type": "string",
+            "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/requiresFollowUp",
+            "name": "requiresFollowUp",
+            "type": "boolean",
             "modifiers": [],
             "position": {}
           },

--- a/tests/data-clumps/test-cases/parameter-parameter/simple/positive/typescript/source/AppointmentScheduler.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple/positive/typescript/source/AppointmentScheduler.ts
@@ -1,5 +1,7 @@
 export class AppointmentScheduler {
-  schedule(patientId: string, doctorId: string, roomNumber: string): void {
-    console.log(`Scheduling appointment for ${patientId} with ${doctorId} in room ${roomNumber}`);
+  schedule(patientId: number, doctorId: number, requiresFollowUp: boolean): void {
+    console.log(
+      `Scheduling appointment for patient ${patientId} with doctor ${doctorId} (requires follow-up: ${requiresFollowUp})`
+    );
   }
 }

--- a/tests/data-clumps/test-cases/parameter-parameter/simple/positive/typescript/source/BillingProcessor.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple/positive/typescript/source/BillingProcessor.ts
@@ -1,5 +1,7 @@
 export class BillingProcessor {
-  createInvoice(patientId: string, doctorId: string, roomNumber: string): void {
-    console.log(`Creating invoice for ${patientId} and doctor ${doctorId} in room ${roomNumber}`);
+  createInvoice(patientId: number, doctorId: number, requiresFollowUp: boolean): void {
+    console.log(
+      `Creating invoice for patient ${patientId} and doctor ${doctorId} (requires follow-up: ${requiresFollowUp})`
+    );
   }
 }


### PR DESCRIPTION
## Summary
- replace string-based fields and parameters in TypeScript and Java test fixtures with numeric and boolean primitives
- refresh the associated expected reports so the detector output reflects the new primitive types and field keys

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce7d0a31f48330841aafb4cf016745