### PR TITLE
Add non-primitive datatype scenario tests

### DIFF
--- a/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/java/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/java/report-expected.json
@@ -1,0 +1,283 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-20T10:38:16.550Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToClasses": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 2,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java field-field data clump with non-primitive datatypes",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 3,
+    "number_of_classes_or_interfaces": 3,
+    "number_of_methods": 0,
+    "number_of_data_fields": 6,
+    "number_of_method_parameters": 0
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "fields_to_fields_data_clump-Doctor.java-Doctor-Patient-kastaniefirstnameaddress": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Doctor.java-Doctor-Patient-kastaniefirstnameaddress",
+      "probability": 1,
+      "from_file_path": "Doctor.java",
+      "from_class_or_interface_name": "Doctor",
+      "from_class_or_interface_key": "Doctor",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Patient.java",
+      "to_class_or_interface_key": "Patient",
+      "to_class_or_interface_name": "Doctor",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Doctor/memberField/kastanie": {
+          "key": "Doctor/memberField/kastanie",
+          "name": "kastanie",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient/memberField/kastanie",
+            "name": "kastanie",
+            "type": "java.lang.String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 3,
+              "startColumn": 19,
+              "endLine": 3,
+              "endColumn": 27
+            }
+          },
+          "position": {
+            "startLine": 3,
+            "startColumn": 19,
+            "endLine": 3,
+            "endColumn": 27
+          }
+        },
+        "Doctor/memberField/firstname": {
+          "key": "Doctor/memberField/firstname",
+          "name": "firstname",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient/memberField/firstname",
+            "name": "firstname",
+            "type": "java.lang.String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 2,
+              "startColumn": 19,
+              "endLine": 2,
+              "endColumn": 28
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 19,
+            "endLine": 2,
+            "endColumn": 28
+          }
+        },
+        "Doctor/memberField/address": {
+          "key": "Doctor/memberField/address",
+          "name": "address",
+          "type": "Adress",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient/memberField/address",
+            "name": "address",
+            "type": "Adress",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 4,
+              "startColumn": 19,
+              "endLine": 4,
+              "endColumn": 26
+            }
+          },
+          "position": {
+            "startLine": 4,
+            "startColumn": 19,
+            "endLine": 4,
+            "endColumn": 26
+          }
+        }
+      }
+    },
+    "fields_to_fields_data_clump-Patient.java-Patient-Doctor-addressfirstnamekastanie": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Patient.java-Patient-Doctor-addressfirstnamekastanie",
+      "probability": 1,
+      "from_file_path": "Patient.java",
+      "from_class_or_interface_name": "Patient",
+      "from_class_or_interface_key": "Patient",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Doctor.java",
+      "to_class_or_interface_key": "Doctor",
+      "to_class_or_interface_name": "Patient",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Patient/memberField/address": {
+          "key": "Patient/memberField/address",
+          "name": "address",
+          "type": "Adress",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor/memberField/address",
+            "name": "address",
+            "type": "Adress",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 4,
+              "startColumn": 19,
+              "endLine": 4,
+              "endColumn": 26
+            }
+          },
+          "position": {
+            "startLine": 4,
+            "startColumn": 19,
+            "endLine": 4,
+            "endColumn": 26
+          }
+        },
+        "Patient/memberField/firstname": {
+          "key": "Patient/memberField/firstname",
+          "name": "firstname",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor/memberField/firstname",
+            "name": "firstname",
+            "type": "java.lang.String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 2,
+              "startColumn": 19,
+              "endLine": 2,
+              "endColumn": 28
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 19,
+            "endLine": 2,
+            "endColumn": 28
+          }
+        },
+        "Patient/memberField/kastanie": {
+          "key": "Patient/memberField/kastanie",
+          "name": "kastanie",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor/memberField/kastanie",
+            "name": "kastanie",
+            "type": "java.lang.String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 3,
+              "startColumn": 19,
+              "endLine": 3,
+              "endColumn": 27
+            }
+          },
+          "position": {
+            "startLine": 3,
+            "startColumn": 19,
+            "endLine": 3,
+            "endColumn": 27
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/java/source/Adress.java
+++ b/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/java/source/Adress.java
@@ -1,0 +1,2 @@
+public class Adress {
+}

--- a/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/java/source/Doctor.java
+++ b/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/java/source/Doctor.java
@@ -1,0 +1,11 @@
+public class Doctor {
+    public String firstname;
+    public String kastanie;
+    public Adress address;
+
+    public Doctor(String firstname, String kastanie, Adress address) {
+        this.firstname = firstname;
+        this.kastanie = kastanie;
+        this.address = address;
+    }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/java/source/Patient.java
+++ b/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/java/source/Patient.java
@@ -1,0 +1,11 @@
+public class Patient {
+    public String firstname;
+    public String kastanie;
+    public Adress address;
+
+    public Patient(String firstname, String kastanie, Adress address) {
+        this.firstname = firstname;
+        this.kastanie = kastanie;
+        this.address = address;
+    }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/java/test.config.json
+++ b/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/java/test.config.json
@@ -1,0 +1,7 @@
+{
+  "name": "Java field-field data clump with non-primitive datatypes",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {}
+}

--- a/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/report-expected.json
@@ -1,0 +1,223 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-20T10:38:14.691Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToClasses": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 2,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript field-field data clump with non-primitive datatypes",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 3,
+    "number_of_classes_or_interfaces": 3,
+    "number_of_methods": 0,
+    "number_of_data_fields": 6,
+    "number_of_method_parameters": 0
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "fields_to_fields_data_clump-Doctor.ts-Doctor.ts/class/Doctor-Patient.ts/class/Patient-firstnamekastanieaddress": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Doctor.ts-Doctor.ts/class/Doctor-Patient.ts/class/Patient-firstnamekastanieaddress",
+      "probability": 1,
+      "from_file_path": "Doctor.ts",
+      "from_class_or_interface_name": "Doctor",
+      "from_class_or_interface_key": "Doctor.ts/class/Doctor",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Patient.ts",
+      "to_class_or_interface_key": "Patient.ts/class/Patient",
+      "to_class_or_interface_name": "Doctor",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Doctor.ts/class/Doctor/memberField/firstname": {
+          "key": "Doctor.ts/class/Doctor/memberField/firstname",
+          "name": "firstname",
+          "type": "String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/firstname",
+            "name": "firstname",
+            "type": "String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Doctor.ts/class/Doctor/memberField/kastanie": {
+          "key": "Doctor.ts/class/Doctor/memberField/kastanie",
+          "name": "kastanie",
+          "type": "String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/kastanie",
+            "name": "kastanie",
+            "type": "String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Doctor.ts/class/Doctor/memberField/address": {
+          "key": "Doctor.ts/class/Doctor/memberField/address",
+          "name": "address",
+          "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/address",
+            "name": "address",
+            "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    },
+    "fields_to_fields_data_clump-Patient.ts-Patient.ts/class/Patient-Doctor.ts/class/Doctor-firstnamekastanieaddress": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Patient.ts-Patient.ts/class/Patient-Doctor.ts/class/Doctor-firstnamekastanieaddress",
+      "probability": 1,
+      "from_file_path": "Patient.ts",
+      "from_class_or_interface_name": "Patient",
+      "from_class_or_interface_key": "Patient.ts/class/Patient",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Doctor.ts",
+      "to_class_or_interface_key": "Doctor.ts/class/Doctor",
+      "to_class_or_interface_name": "Patient",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Patient.ts/class/Patient/memberField/firstname": {
+          "key": "Patient.ts/class/Patient/memberField/firstname",
+          "name": "firstname",
+          "type": "String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor.ts/class/Doctor/memberField/firstname",
+            "name": "firstname",
+            "type": "String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Patient.ts/class/Patient/memberField/kastanie": {
+          "key": "Patient.ts/class/Patient/memberField/kastanie",
+          "name": "kastanie",
+          "type": "String",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor.ts/class/Doctor/memberField/kastanie",
+            "name": "kastanie",
+            "type": "String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Patient.ts/class/Patient/memberField/address": {
+          "key": "Patient.ts/class/Patient/memberField/address",
+          "name": "address",
+          "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor.ts/class/Doctor/memberField/address",
+            "name": "address",
+            "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Adress.ts
+++ b/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Adress.ts
@@ -1,0 +1,1 @@
+export class Adress {}

--- a/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Doctor.ts
+++ b/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Doctor.ts
@@ -1,0 +1,13 @@
+import { Adress } from './Adress';
+
+export class Doctor {
+  public firstname: String;
+  public kastanie: String;
+  public address: Adress;
+
+  constructor(firstname: String, kastanie: String, address: Adress) {
+    this.firstname = firstname;
+    this.kastanie = kastanie;
+    this.address = address;
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Patient.ts
+++ b/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Patient.ts
@@ -1,0 +1,13 @@
+import { Adress } from './Adress';
+
+export class Patient {
+  public firstname: String;
+  public kastanie: String;
+  public address: Adress;
+
+  constructor(firstname: String, kastanie: String, address: Adress) {
+    this.firstname = firstname;
+    this.kastanie = kastanie;
+    this.address = address;
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/test.config.json
@@ -1,0 +1,7 @@
+{
+  "name": "TypeScript field-field data clump with non-primitive datatypes",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {}
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/java/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/java/report-expected.json
@@ -1,0 +1,172 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-20T10:38:14.017Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 1,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 3,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": 1,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 3,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": 1,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 3,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 1,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 1,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 1,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 1
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java parameter-field data clump with non-primitive datatypes",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 3,
+    "number_of_classes_or_interfaces": 3,
+    "number_of_methods": 1,
+    "number_of_data_fields": 3,
+    "number_of_method_parameters": 3
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "parameters_to_fields_data_clump-PatientService.java-PatientService/method/registerPatient(java.lang.String firstname, java.lang.String kastanie, Adress address)-Patient-firstnamekastanieaddress": {
+      "type": "data_clump",
+      "key": "parameters_to_fields_data_clump-PatientService.java-PatientService/method/registerPatient(java.lang.String firstname, java.lang.String kastanie, Adress address)-Patient-firstnamekastanieaddress",
+      "probability": 1,
+      "from_file_path": "PatientService.java",
+      "from_class_or_interface_name": "PatientService",
+      "from_class_or_interface_key": "PatientService",
+      "from_method_name": "registerPatient",
+      "from_method_key": "PatientService/method/registerPatient(java.lang.String firstname, java.lang.String kastanie, Adress address)",
+      "to_file_path": "Patient.java",
+      "to_class_or_interface_name": "Patient",
+      "to_class_or_interface_key": "Patient",
+      "to_method_name": null,
+      "to_method_key": null,
+      "data_clump_type": "parameters_to_fields_data_clump",
+      "data_clump_data": {
+        "PatientService/method/registerPatient(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/firstname": {
+          "key": "PatientService/method/registerPatient(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/firstname",
+          "name": "firstname",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "Patient/memberField/firstname",
+            "name": "firstname",
+            "type": "java.lang.String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 2,
+              "startColumn": 19,
+              "endLine": 2,
+              "endColumn": 28
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 40,
+            "endLine": 2,
+            "endColumn": 49
+          }
+        },
+        "PatientService/method/registerPatient(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/kastanie": {
+          "key": "PatientService/method/registerPatient(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/kastanie",
+          "name": "kastanie",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "Patient/memberField/kastanie",
+            "name": "kastanie",
+            "type": "java.lang.String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 3,
+              "startColumn": 19,
+              "endLine": 3,
+              "endColumn": 27
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 58,
+            "endLine": 2,
+            "endColumn": 66
+          }
+        },
+        "PatientService/method/registerPatient(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/address": {
+          "key": "PatientService/method/registerPatient(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/address",
+          "name": "address",
+          "type": "Adress",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "Patient/memberField/address",
+            "name": "address",
+            "type": "Adress",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 4,
+              "startColumn": 19,
+              "endLine": 4,
+              "endColumn": 26
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 75,
+            "endLine": 2,
+            "endColumn": 82
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/java/source/Adress.java
+++ b/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/java/source/Adress.java
@@ -1,0 +1,2 @@
+public class Adress {
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/java/source/Patient.java
+++ b/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/java/source/Patient.java
@@ -1,0 +1,11 @@
+public class Patient {
+    public String firstname;
+    public String kastanie;
+    public Adress address;
+
+    public Patient(String firstname, String kastanie, Adress address) {
+        this.firstname = firstname;
+        this.kastanie = kastanie;
+        this.address = address;
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/java/source/PatientService.java
+++ b/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/java/source/PatientService.java
@@ -1,0 +1,6 @@
+public class PatientService {
+    public void registerPatient(String firstname, String kastanie, Adress address) {
+        System.out.println(
+                "Registering patient " + firstname + " with kastanie " + kastanie + " (address: " + address + ")");
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/java/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/java/test.config.json
@@ -1,0 +1,7 @@
+{
+  "name": "Java parameter-field data clump with non-primitive datatypes",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {}
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/report-expected.json
@@ -1,0 +1,142 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-20T10:38:12.137Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 1,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 3,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": 1,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 3,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": 1,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 3,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 1,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 1,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 1,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 1
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript parameter-field data clump with non-primitive datatypes",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 3,
+    "number_of_classes_or_interfaces": 3,
+    "number_of_methods": 1,
+    "number_of_data_fields": 3,
+    "number_of_method_parameters": 3
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "parameters_to_fields_data_clump-PatientService.ts-PatientService.ts/class/PatientService/method/registerPatient-Patient.ts/class/Patient-firstnamekastanieaddress": {
+      "type": "data_clump",
+      "key": "parameters_to_fields_data_clump-PatientService.ts-PatientService.ts/class/PatientService/method/registerPatient-Patient.ts/class/Patient-firstnamekastanieaddress",
+      "probability": 1,
+      "from_file_path": "PatientService.ts",
+      "from_class_or_interface_name": "PatientService",
+      "from_class_or_interface_key": "PatientService.ts/class/PatientService",
+      "from_method_name": "registerPatient",
+      "from_method_key": "PatientService.ts/class/PatientService/method/registerPatient",
+      "to_file_path": "Patient.ts",
+      "to_class_or_interface_name": "Patient",
+      "to_class_or_interface_key": "Patient.ts/class/Patient",
+      "to_method_name": null,
+      "to_method_key": null,
+      "data_clump_type": "parameters_to_fields_data_clump",
+      "data_clump_data": {
+        "PatientService.ts/class/PatientService/method/registerPatient/parameter/firstname": {
+          "key": "PatientService.ts/class/PatientService/method/registerPatient/parameter/firstname",
+          "name": "firstname",
+          "type": "String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/firstname",
+            "name": "firstname",
+            "type": "String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "PatientService.ts/class/PatientService/method/registerPatient/parameter/kastanie": {
+          "key": "PatientService.ts/class/PatientService/method/registerPatient/parameter/kastanie",
+          "name": "kastanie",
+          "type": "String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/kastanie",
+            "name": "kastanie",
+            "type": "String",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "PatientService.ts/class/PatientService/method/registerPatient/parameter/address": {
+          "key": "PatientService.ts/class/PatientService/method/registerPatient/parameter/address",
+          "name": "address",
+          "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/address",
+            "name": "address",
+            "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/source/Adress.ts
+++ b/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/source/Adress.ts
@@ -1,0 +1,1 @@
+export class Adress {}

--- a/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/source/Patient.ts
+++ b/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/source/Patient.ts
@@ -1,0 +1,13 @@
+import { Adress } from './Adress';
+
+export class Patient {
+  public firstname: String;
+  public kastanie: String;
+  public address: Adress;
+
+  constructor(firstname: String, kastanie: String, address: Adress) {
+    this.firstname = firstname;
+    this.kastanie = kastanie;
+    this.address = address;
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/source/PatientService.ts
+++ b/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/source/PatientService.ts
@@ -1,0 +1,7 @@
+import { Adress } from './Adress';
+
+export class PatientService {
+  registerPatient(firstname: String, kastanie: String, address: Adress): void {
+    console.log(`Registering patient ${firstname} with kastanie ${kastanie} (address provided: ${address instanceof Adress})`);
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/test.config.json
@@ -1,0 +1,7 @@
+{
+  "name": "TypeScript parameter-field data clump with non-primitive datatypes",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {}
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/java/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/java/report-expected.json
@@ -1,0 +1,259 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-20T10:38:11.365Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToMethods": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 2,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 2,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java parameter-parameter data clump with non-primitive datatypes",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 3,
+    "number_of_classes_or_interfaces": 3,
+    "number_of_methods": 2,
+    "number_of_data_fields": 0,
+    "number_of_method_parameters": 6
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "parameters_to_parameters_data_clump-AppointmentScheduler.java-AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)-BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)-firstnamekastanieaddress": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-AppointmentScheduler.java-AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)-BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)-firstnamekastanieaddress",
+      "probability": 1,
+      "from_file_path": "AppointmentScheduler.java",
+      "from_class_or_interface_name": "AppointmentScheduler",
+      "from_class_or_interface_key": "AppointmentScheduler",
+      "from_method_name": "schedule",
+      "from_method_key": "AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)",
+      "to_file_path": "BillingProcessor.java",
+      "to_class_or_interface_name": "BillingProcessor",
+      "to_class_or_interface_key": "BillingProcessor",
+      "to_method_name": "createInvoice",
+      "to_method_key": "BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/firstname": {
+          "key": "AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/firstname",
+          "name": "firstname",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/firstname",
+            "name": "firstname",
+            "type": "java.lang.String",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 38,
+              "endLine": 2,
+              "endColumn": 47
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 33,
+            "endLine": 2,
+            "endColumn": 42
+          }
+        },
+        "AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/kastanie": {
+          "key": "AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/kastanie",
+          "name": "kastanie",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/kastanie",
+            "name": "kastanie",
+            "type": "java.lang.String",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 56,
+              "endLine": 2,
+              "endColumn": 64
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 51,
+            "endLine": 2,
+            "endColumn": 59
+          }
+        },
+        "AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/address": {
+          "key": "AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/address",
+          "name": "address",
+          "type": "Adress",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/address",
+            "name": "address",
+            "type": "Adress",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 73,
+              "endLine": 2,
+              "endColumn": 80
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 68,
+            "endLine": 2,
+            "endColumn": 75
+          }
+        }
+      }
+    },
+    "parameters_to_parameters_data_clump-BillingProcessor.java-BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)-AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)-firstnamekastanieaddress": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-BillingProcessor.java-BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)-AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)-firstnamekastanieaddress",
+      "probability": 1,
+      "from_file_path": "BillingProcessor.java",
+      "from_class_or_interface_name": "BillingProcessor",
+      "from_class_or_interface_key": "BillingProcessor",
+      "from_method_name": "createInvoice",
+      "from_method_key": "BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)",
+      "to_file_path": "AppointmentScheduler.java",
+      "to_class_or_interface_name": "AppointmentScheduler",
+      "to_class_or_interface_key": "AppointmentScheduler",
+      "to_method_name": "schedule",
+      "to_method_key": "AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/firstname": {
+          "key": "BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/firstname",
+          "name": "firstname",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/firstname",
+            "name": "firstname",
+            "type": "java.lang.String",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 33,
+              "endLine": 2,
+              "endColumn": 42
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 38,
+            "endLine": 2,
+            "endColumn": 47
+          }
+        },
+        "BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/kastanie": {
+          "key": "BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/kastanie",
+          "name": "kastanie",
+          "type": "java.lang.String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/kastanie",
+            "name": "kastanie",
+            "type": "java.lang.String",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 51,
+              "endLine": 2,
+              "endColumn": 59
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 56,
+            "endLine": 2,
+            "endColumn": 64
+          }
+        },
+        "BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/address": {
+          "key": "BillingProcessor/method/createInvoice(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/address",
+          "name": "address",
+          "type": "Adress",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler/method/schedule(java.lang.String firstname, java.lang.String kastanie, Adress address)/parameter/address",
+            "name": "address",
+            "type": "Adress",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 68,
+              "endLine": 2,
+              "endColumn": 75
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 73,
+            "endLine": 2,
+            "endColumn": 80
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/java/source/Adress.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/java/source/Adress.java
@@ -1,0 +1,2 @@
+public class Adress {
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/java/source/AppointmentScheduler.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/java/source/AppointmentScheduler.java
@@ -1,0 +1,6 @@
+public class AppointmentScheduler {
+    public void schedule(String firstname, String kastanie, Adress address) {
+        System.out.println(
+                "Scheduling appointment for " + firstname + " with kastanie " + kastanie + " (address: " + address + ")");
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/java/source/BillingProcessor.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/java/source/BillingProcessor.java
@@ -1,0 +1,6 @@
+public class BillingProcessor {
+    public void createInvoice(String firstname, String kastanie, Adress address) {
+        System.out.println(
+                "Creating invoice for " + firstname + " with kastanie " + kastanie + " (address: " + address + ")");
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/java/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/java/test.config.json
@@ -1,0 +1,7 @@
+{
+  "name": "Java parameter-parameter data clump with non-primitive datatypes",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {}
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/report-expected.json
@@ -1,0 +1,199 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-20T10:38:08.524Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToMethods": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 2,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 2,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript parameter-parameter data clump with non-primitive datatypes",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 3,
+    "number_of_classes_or_interfaces": 3,
+    "number_of_methods": 2,
+    "number_of_data_fields": 0,
+    "number_of_method_parameters": 6
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "parameters_to_parameters_data_clump-AppointmentScheduler.ts-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-firstnamekastanieaddress": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-AppointmentScheduler.ts-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-firstnamekastanieaddress",
+      "probability": 1,
+      "from_file_path": "AppointmentScheduler.ts",
+      "from_class_or_interface_name": "AppointmentScheduler",
+      "from_class_or_interface_key": "AppointmentScheduler.ts/class/AppointmentScheduler",
+      "from_method_name": "schedule",
+      "from_method_key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule",
+      "to_file_path": "BillingProcessor.ts",
+      "to_class_or_interface_name": "BillingProcessor",
+      "to_class_or_interface_key": "BillingProcessor.ts/class/BillingProcessor",
+      "to_method_name": "createInvoice",
+      "to_method_key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/firstname": {
+          "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/firstname",
+          "name": "firstname",
+          "type": "String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/firstname",
+            "name": "firstname",
+            "type": "String",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        },
+        "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/kastanie": {
+          "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/kastanie",
+          "name": "kastanie",
+          "type": "String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/kastanie",
+            "name": "kastanie",
+            "type": "String",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        },
+        "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/address": {
+          "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/address",
+          "name": "address",
+          "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/address",
+            "name": "address",
+            "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    },
+    "parameters_to_parameters_data_clump-BillingProcessor.ts-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-firstnamekastanieaddress": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-BillingProcessor.ts-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-firstnamekastanieaddress",
+      "probability": 1,
+      "from_file_path": "BillingProcessor.ts",
+      "from_class_or_interface_name": "BillingProcessor",
+      "from_class_or_interface_key": "BillingProcessor.ts/class/BillingProcessor",
+      "from_method_name": "createInvoice",
+      "from_method_key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice",
+      "to_file_path": "AppointmentScheduler.ts",
+      "to_class_or_interface_name": "AppointmentScheduler",
+      "to_class_or_interface_key": "AppointmentScheduler.ts/class/AppointmentScheduler",
+      "to_method_name": "schedule",
+      "to_method_key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/firstname": {
+          "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/firstname",
+          "name": "firstname",
+          "type": "String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/firstname",
+            "name": "firstname",
+            "type": "String",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        },
+        "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/kastanie": {
+          "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/kastanie",
+          "name": "kastanie",
+          "type": "String",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/kastanie",
+            "name": "kastanie",
+            "type": "String",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        },
+        "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/address": {
+          "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/address",
+          "name": "address",
+          "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/address",
+            "name": "address",
+            "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/source/Adress.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/source/Adress.ts
@@ -1,0 +1,1 @@
+export class Adress {}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/source/AppointmentScheduler.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/source/AppointmentScheduler.ts
@@ -1,0 +1,9 @@
+import { Adress } from './Adress';
+
+export class AppointmentScheduler {
+  schedule(firstname: String, kastanie: String, address: Adress): void {
+    console.log(
+      `Scheduling appointment for ${firstname} with kastanie ${kastanie} (address: ${address instanceof Adress})`
+    );
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/source/BillingProcessor.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/source/BillingProcessor.ts
@@ -1,0 +1,9 @@
+import { Adress } from './Adress';
+
+export class BillingProcessor {
+  createInvoice(firstname: String, kastanie: String, address: Adress): void {
+    console.log(
+      `Creating invoice for ${firstname} with kastanie ${kastanie} (address: ${address instanceof Adress})`
+    );
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/test.config.json
@@ -1,0 +1,7 @@
+{
+  "name": "TypeScript parameter-parameter data clump with non-primitive datatypes",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {}
+}


### PR DESCRIPTION
## Summary
- add TypeScript and Java parameter-to-parameter scenarios that use String and Adress parameters
- cover parameter-to-field and field-to-field data clumps with non-primitive datatypes in both languages
- record detector expectations for every new scenario

## Testing
- npm run testOnly

------
https://chatgpt.com/codex/tasks/task_e_68ce8367b49c833096e5c299b4692dd3