### PR TITLE
Regenerate TypeScript non-primitive expected reports

### DIFF
--- a/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/report-expected.json
@@ -1,6 +1,6 @@
 {
   "report_version": "^0.1.102",
-  "report_timestamp": "2025-09-20T10:38:14.691Z",
+  "report_timestamp": "2025-09-20T11:07:42.223Z",
   "target_language": "typescript",
   "report_summary": {
     "additional": {
@@ -90,12 +90,16 @@
           "name": "firstname",
           "type": "String",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Patient.ts/class/Patient/memberField/firstname",
             "name": "firstname",
             "type": "String",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -105,12 +109,16 @@
           "name": "kastanie",
           "type": "String",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Patient.ts/class/Patient/memberField/kastanie",
             "name": "kastanie",
             "type": "String",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -120,12 +128,16 @@
           "name": "address",
           "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Patient.ts/class/Patient/memberField/address",
             "name": "address",
             "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -153,12 +165,16 @@
           "name": "firstname",
           "type": "String",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Doctor.ts/class/Doctor/memberField/firstname",
             "name": "firstname",
             "type": "String",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -168,12 +184,16 @@
           "name": "kastanie",
           "type": "String",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Doctor.ts/class/Doctor/memberField/kastanie",
             "name": "kastanie",
             "type": "String",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -183,12 +203,16 @@
           "name": "address",
           "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
           "probability": 1,
-          "modifiers": ["PUBLIC"],
+          "modifiers": [
+            "PUBLIC"
+          ],
           "to_variable": {
             "key": "Doctor.ts/class/Doctor/memberField/address",
             "name": "address",
             "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/field-field/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}

--- a/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/report-expected.json
@@ -1,6 +1,6 @@
 {
   "report_version": "^0.1.102",
-  "report_timestamp": "2025-09-20T10:38:12.137Z",
+  "report_timestamp": "2025-09-20T11:07:41.355Z",
   "target_language": "typescript",
   "report_summary": {
     "additional": {
@@ -95,7 +95,9 @@
             "key": "Patient.ts/class/Patient/memberField/firstname",
             "name": "firstname",
             "type": "String",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -110,7 +112,9 @@
             "key": "Patient.ts/class/Patient/memberField/kastanie",
             "name": "kastanie",
             "type": "String",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}
@@ -125,7 +129,9 @@
             "key": "Patient.ts/class/Patient/memberField/address",
             "name": "address",
             "type": "import(\"/workspace/data-clumps-doctor/tests/data-clumps/test-cases/parameter-field/simple-non-primitive-datatypes/positive/typescript/source/Adress\").Adress",
-            "modifiers": ["PUBLIC"],
+            "modifiers": [
+              "PUBLIC"
+            ],
             "position": {}
           },
           "position": {}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-non-primitive-datatypes/positive/typescript/report-expected.json
@@ -1,6 +1,6 @@
 {
   "report_version": "^0.1.102",
-  "report_timestamp": "2025-09-20T10:38:08.524Z",
+  "report_timestamp": "2025-09-20T11:07:40.359Z",
   "target_language": "typescript",
   "report_summary": {
     "additional": {


### PR DESCRIPTION
## Summary
- regenerate the expected reports for the TypeScript non-primitive parameter-parameter, parameter-field, and field-field scenarios so they match freshly generated detector output

## Testing
- `npm run testOnly`


------
https://chatgpt.com/codex/tasks/task_e_68ce8ac7ba048330b2a2abe59f42e0d1