### PR TITLE
Add workflow to regenerate existing test reports

### DIFF
--- a/.github/workflows/regenerate-existing-test-reports.yml
+++ b/.github/workflows/regenerate-existing-test-reports.yml
@@ -1,0 +1,31 @@
+name: "♻️ Regenerate existing test reports"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  regenerate:
+    name: "♻️ Regenerate expected test reports"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "🔄 Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: "⚙️ Setup Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.16.0"
+      - name: "⚙️ Enable Corepack"
+        run: corepack enable
+      - name: "📦 Install dependencies"
+        run: yarn install --immutable
+      - name: "🧪 Regenerate expected reports"
+        run: yarn regenerate-existing-test-report-expected
+      - name: "📤 Upload regenerated expected reports"
+        uses: actions/upload-artifact@v4
+        with:
+          name: regenerated-expected-test-reports
+          path: |
+            tests/data-clumps/test-cases/**/report-expected*.json
+          if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "yarn run build && yarn run testOnly",
     "testOnly": "jest --coverage=false",
     "generate-missing-test-reports": "yarn run build && node ./build/tests/generateMissingReports.js",
+    "regenerate-existing-test-report-expected": "yarn run build && node ./build/tests/regenerateExistingReports.js",
     "start": "yarn run build && node ./build/ignoreCoverage/development.js",
     "build": "rimraf ./build && tsc && mkdir -p ./build/src/ignoreCoverage && cp -r ./src/ignoreCoverage/astGenerator ./build/src/ignoreCoverage/ && cp -r ./build/src/ignoreCoverage ./build/ignoreCoverage && cp ./build/src/index.js ./build/index.js && cp ./build/src/index.d.ts ./build/index.d.ts && cp package.json ./build && cp ./README.md ./build && cp ./LICENSE.md ./build && npm run chmodCli",
     "chmodCli": "chmod +x ./build/ignoreCoverage/cli.js",

--- a/tests/regenerateExistingReports.ts
+++ b/tests/regenerateExistingReports.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import path from 'path';
+import minimist from 'minimist';
+
+import { resolveTestCasesBaseDir, runScenario, Scenario } from './data-clumps/scenarioUtils';
+
+async function regenerateExpectedReportForScenario(scenario: Scenario) {
+  const report = await runScenario(scenario);
+  const outputPath = path.resolve(scenario.expectedReportPath);
+  fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(`Regenerated expected report for "${scenario.name}" at ${outputPath}`);
+}
+
+async function main() {
+  const args = minimist(process.argv.slice(2));
+  const scenarioId = args.id as string | undefined;
+  const { scenarios, baseDir } = resolveTestCasesBaseDir();
+
+  let filteredScenarios = scenarios;
+  if (scenarioId) {
+    filteredScenarios = scenarios.filter(scenario => scenario.id === scenarioId);
+  }
+
+  if (filteredScenarios.length === 0) {
+    console.error(`No scenarios discovered in ${baseDir}${scenarioId ? ` for id=${scenarioId}` : ''}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const scenariosWithExpected = filteredScenarios.filter(scenario => fs.existsSync(scenario.expectedReportPath));
+
+  if (scenariosWithExpected.length === 0) {
+    console.log('No scenarios with existing expected reports found. Nothing to regenerate.');
+    return;
+  }
+
+  for (const scenario of scenariosWithExpected) {
+    await regenerateExpectedReportForScenario(scenario);
+  }
+}
+
+void main();


### PR DESCRIPTION
## Summary
- add a TypeScript helper that regenerates existing expected test reports
- expose the helper via a `regenerate-existing-test-report-expected` npm script
- provide a manually triggered workflow that runs the script and uploads the refreshed reports

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cec9f57a1c833090157eaface30ede