### PR TITLE
Prevent regen script from running during Jest

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -155,6 +155,7 @@ export default {
     '/src/ignoreCoverage/',
     '/tests/.*/source/',
     'generateMissingReports',
+    'regenerateExistingReports',
     'scenarioUtils',
   ],
 

--- a/tests/regenerateExistingReports.ts
+++ b/tests/regenerateExistingReports.ts
@@ -39,4 +39,6 @@ async function main() {
   }
 }
 
-void main();
+if (require.main === module) {
+  void main();
+}


### PR DESCRIPTION
## Summary
- avoid executing the regenerateExistingReports helper when it is loaded by Jest so its logging no longer fires after the test run
- tell Jest to ignore the regenerateExistingReports helper file during test discovery so the CLI script is not treated as a test suite

## Testing
- yarn test *(fails: existing TypeScript data clump fixtures do not match expected reports)*

------
https://chatgpt.com/codex/tasks/task_e_68cecdd35eec8330a4e49c4cdb1d5d29