### PR TITLE
Add interface parameter scenarios and update TypeScript parser

### DIFF
--- a/src/ignoreCoverage/parsers/ParserHelperTypeScript.ts
+++ b/src/ignoreCoverage/parsers/ParserHelperTypeScript.ts
@@ -119,7 +119,25 @@ export class ParserHelperTypeScript extends ParserBase implements ParserInterfac
           ctx.fields[field.key] = field;
         }
 
-        dict[ctx.key] = ctx;
+        for (const method of intf.getMethods()) {
+          const methodName = method.getName();
+          const methodKey = methodName;
+          const returnTypeText = this.normalizeTypeText(method.getReturnType().getText(), path_to_source_folder);
+          const methodCtx = new MethodTypeContext(methodKey, methodName, returnTypeText, false, ctx);
+          methodCtx.modifiers = [];
+
+          for (const param of method.getParameters()) {
+            const paramName = param.getName();
+            const paramKey = paramName;
+            const paramType = this.normalizeTypeText(param.getType().getText(), path_to_source_folder);
+            const paramCtx = new MethodParameterTypeContext(paramKey, paramName, paramType, [], false, methodCtx);
+            methodCtx.parameters.push(paramCtx);
+          }
+
+          ctx.methods[methodCtx.key] = methodCtx;
+        }
+
+        dict.set(ctx.key, ctx);
       }
     }
 

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/java/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/java/report-expected.json
@@ -1,0 +1,72 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-20T22:56:37.422Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToMethods": {
+          "median": 1.5,
+          "maximum": 2,
+          "average": 1.5,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 2
+        },
+        "invertedParameterToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 0,
+    "amount_files_with_data_clumps": 0,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 0
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java parameter-parameter interfaces without enough shared parameters",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 2,
+    "number_of_data_fields": 0,
+    "number_of_method_parameters": 6
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {}
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/java/source/AppointmentScheduler.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/java/source/AppointmentScheduler.java
@@ -1,0 +1,3 @@
+public interface AppointmentScheduler {
+  void schedule(int patientId, int doctorId, boolean requiresFollowUp);
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/java/source/BillingProcessor.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/java/source/BillingProcessor.java
@@ -1,0 +1,3 @@
+public interface BillingProcessor {
+  void createInvoice(int patientId, int doctorId, double invoiceAmount);
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/java/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/java/test.config.json
@@ -1,0 +1,8 @@
+{
+  "id": "parameter-parameter-todo-interfaces-negative-java",
+  "name": "Java parameter-parameter interfaces without enough shared parameters",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {}
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/typescript/report-expected.json
@@ -1,0 +1,72 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-20T22:58:42.519Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToMethods": {
+          "median": 1.5,
+          "maximum": 2,
+          "average": 1.5,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 2
+        },
+        "invertedParameterToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 0,
+    "amount_files_with_data_clumps": 0,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 0
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript parameter-parameter interfaces without enough shared parameters",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 2,
+    "number_of_data_fields": 0,
+    "number_of_method_parameters": 6
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {}
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/typescript/source/AppointmentScheduler.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/typescript/source/AppointmentScheduler.ts
@@ -1,0 +1,7 @@
+export interface AppointmentScheduler {
+  schedule(
+    patientId: number,
+    doctorId: number,
+    requiresFollowUp: boolean
+  ): void;
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/typescript/source/BillingProcessor.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/typescript/source/BillingProcessor.ts
@@ -1,0 +1,7 @@
+export interface BillingProcessor {
+  createInvoice(
+    patientId: number,
+    doctorId: number,
+    invoiceAmount: number
+  ): void;
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/negative/typescript/test.config.json
@@ -1,0 +1,8 @@
+{
+  "id": "parameter-parameter-todo-interfaces-negative-typescript",
+  "name": "TypeScript parameter-parameter interfaces without enough shared parameters",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {}
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/java/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/java/report-expected.json
@@ -1,0 +1,259 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-20T22:56:34.532Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToMethods": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 2,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 2,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java parameter-parameter data clump between unrelated interfaces",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 2,
+    "number_of_data_fields": 0,
+    "number_of_method_parameters": 6
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "parameters_to_parameters_data_clump-AppointmentScheduler.java-AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)-BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)-patientIddoctorIdrequiresFollowUp": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-AppointmentScheduler.java-AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)-BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)-patientIddoctorIdrequiresFollowUp",
+      "probability": 1,
+      "from_file_path": "AppointmentScheduler.java",
+      "from_class_or_interface_name": "AppointmentScheduler",
+      "from_class_or_interface_key": "AppointmentScheduler",
+      "from_method_name": "schedule",
+      "from_method_key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)",
+      "to_file_path": "BillingProcessor.java",
+      "to_class_or_interface_name": "BillingProcessor",
+      "to_class_or_interface_key": "BillingProcessor",
+      "to_method_name": "createInvoice",
+      "to_method_key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId": {
+          "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId",
+          "name": "patientId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId",
+            "name": "patientId",
+            "type": "int",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 26,
+              "endLine": 2,
+              "endColumn": 35
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 21,
+            "endLine": 2,
+            "endColumn": 30
+          }
+        },
+        "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId": {
+          "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId",
+          "name": "doctorId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId",
+            "name": "doctorId",
+            "type": "int",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 41,
+              "endLine": 2,
+              "endColumn": 49
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 36,
+            "endLine": 2,
+            "endColumn": 44
+          }
+        },
+        "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp": {
+          "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp",
+          "name": "requiresFollowUp",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp",
+            "name": "requiresFollowUp",
+            "type": "boolean",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 59,
+              "endLine": 2,
+              "endColumn": 75
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 54,
+            "endLine": 2,
+            "endColumn": 70
+          }
+        }
+      }
+    },
+    "parameters_to_parameters_data_clump-BillingProcessor.java-BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)-AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)-patientIddoctorIdrequiresFollowUp": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-BillingProcessor.java-BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)-AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)-patientIddoctorIdrequiresFollowUp",
+      "probability": 1,
+      "from_file_path": "BillingProcessor.java",
+      "from_class_or_interface_name": "BillingProcessor",
+      "from_class_or_interface_key": "BillingProcessor",
+      "from_method_name": "createInvoice",
+      "from_method_key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)",
+      "to_file_path": "AppointmentScheduler.java",
+      "to_class_or_interface_name": "AppointmentScheduler",
+      "to_class_or_interface_key": "AppointmentScheduler",
+      "to_method_name": "schedule",
+      "to_method_key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId": {
+          "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId",
+          "name": "patientId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/patientId",
+            "name": "patientId",
+            "type": "int",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 21,
+              "endLine": 2,
+              "endColumn": 30
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 26,
+            "endLine": 2,
+            "endColumn": 35
+          }
+        },
+        "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId": {
+          "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId",
+          "name": "doctorId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/doctorId",
+            "name": "doctorId",
+            "type": "int",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 36,
+              "endLine": 2,
+              "endColumn": 44
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 41,
+            "endLine": 2,
+            "endColumn": 49
+          }
+        },
+        "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp": {
+          "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp",
+          "name": "requiresFollowUp",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId, boolean requiresFollowUp)/parameter/requiresFollowUp",
+            "name": "requiresFollowUp",
+            "type": "boolean",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 54,
+              "endLine": 2,
+              "endColumn": 70
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 59,
+            "endLine": 2,
+            "endColumn": 75
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/java/source/AppointmentScheduler.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/java/source/AppointmentScheduler.java
@@ -1,0 +1,3 @@
+public interface AppointmentScheduler {
+  void schedule(int patientId, int doctorId, boolean requiresFollowUp);
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/java/source/BillingProcessor.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/java/source/BillingProcessor.java
@@ -1,0 +1,3 @@
+public interface BillingProcessor {
+  void createInvoice(int patientId, int doctorId, boolean requiresFollowUp);
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/java/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/java/test.config.json
@@ -1,0 +1,8 @@
+{
+  "id": "parameter-parameter-todo-interfaces-positive-java",
+  "name": "Java parameter-parameter data clump between unrelated interfaces",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {}
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/typescript/report-expected.json
@@ -1,0 +1,199 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-20T22:58:29.544Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToMethods": {
+          "median": 2,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 6,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 2,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 2,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript parameter-parameter data clump between unrelated interfaces",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 2,
+    "number_of_data_fields": 0,
+    "number_of_method_parameters": 6
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "parameters_to_parameters_data_clump-AppointmentScheduler.ts-AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule-BillingProcessor.ts/interface/BillingProcessor/method/createInvoice-patientIddoctorIdrequiresFollowUp": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-AppointmentScheduler.ts-AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule-BillingProcessor.ts/interface/BillingProcessor/method/createInvoice-patientIddoctorIdrequiresFollowUp",
+      "probability": 1,
+      "from_file_path": "AppointmentScheduler.ts",
+      "from_class_or_interface_name": "AppointmentScheduler",
+      "from_class_or_interface_key": "AppointmentScheduler.ts/interface/AppointmentScheduler",
+      "from_method_name": "schedule",
+      "from_method_key": "AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule",
+      "to_file_path": "BillingProcessor.ts",
+      "to_class_or_interface_name": "BillingProcessor",
+      "to_class_or_interface_key": "BillingProcessor.ts/interface/BillingProcessor",
+      "to_method_name": "createInvoice",
+      "to_method_key": "BillingProcessor.ts/interface/BillingProcessor/method/createInvoice",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule/parameter/patientId": {
+          "key": "AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule/parameter/patientId",
+          "name": "patientId",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor.ts/interface/BillingProcessor/method/createInvoice/parameter/patientId",
+            "name": "patientId",
+            "type": "number",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        },
+        "AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule/parameter/doctorId": {
+          "key": "AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule/parameter/doctorId",
+          "name": "doctorId",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor.ts/interface/BillingProcessor/method/createInvoice/parameter/doctorId",
+            "name": "doctorId",
+            "type": "number",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        },
+        "AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule/parameter/requiresFollowUp": {
+          "key": "AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule/parameter/requiresFollowUp",
+          "name": "requiresFollowUp",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor.ts/interface/BillingProcessor/method/createInvoice/parameter/requiresFollowUp",
+            "name": "requiresFollowUp",
+            "type": "boolean",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    },
+    "parameters_to_parameters_data_clump-BillingProcessor.ts-BillingProcessor.ts/interface/BillingProcessor/method/createInvoice-AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule-patientIddoctorIdrequiresFollowUp": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-BillingProcessor.ts-BillingProcessor.ts/interface/BillingProcessor/method/createInvoice-AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule-patientIddoctorIdrequiresFollowUp",
+      "probability": 1,
+      "from_file_path": "BillingProcessor.ts",
+      "from_class_or_interface_name": "BillingProcessor",
+      "from_class_or_interface_key": "BillingProcessor.ts/interface/BillingProcessor",
+      "from_method_name": "createInvoice",
+      "from_method_key": "BillingProcessor.ts/interface/BillingProcessor/method/createInvoice",
+      "to_file_path": "AppointmentScheduler.ts",
+      "to_class_or_interface_name": "AppointmentScheduler",
+      "to_class_or_interface_key": "AppointmentScheduler.ts/interface/AppointmentScheduler",
+      "to_method_name": "schedule",
+      "to_method_key": "AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "BillingProcessor.ts/interface/BillingProcessor/method/createInvoice/parameter/patientId": {
+          "key": "BillingProcessor.ts/interface/BillingProcessor/method/createInvoice/parameter/patientId",
+          "name": "patientId",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule/parameter/patientId",
+            "name": "patientId",
+            "type": "number",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        },
+        "BillingProcessor.ts/interface/BillingProcessor/method/createInvoice/parameter/doctorId": {
+          "key": "BillingProcessor.ts/interface/BillingProcessor/method/createInvoice/parameter/doctorId",
+          "name": "doctorId",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule/parameter/doctorId",
+            "name": "doctorId",
+            "type": "number",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        },
+        "BillingProcessor.ts/interface/BillingProcessor/method/createInvoice/parameter/requiresFollowUp": {
+          "key": "BillingProcessor.ts/interface/BillingProcessor/method/createInvoice/parameter/requiresFollowUp",
+          "name": "requiresFollowUp",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler.ts/interface/AppointmentScheduler/method/schedule/parameter/requiresFollowUp",
+            "name": "requiresFollowUp",
+            "type": "boolean",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/typescript/source/AppointmentScheduler.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/typescript/source/AppointmentScheduler.ts
@@ -1,0 +1,7 @@
+export interface AppointmentScheduler {
+  schedule(
+    patientId: number,
+    doctorId: number,
+    requiresFollowUp: boolean
+  ): void;
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/typescript/source/BillingProcessor.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/typescript/source/BillingProcessor.ts
@@ -1,0 +1,7 @@
+export interface BillingProcessor {
+  createInvoice(
+    patientId: number,
+    doctorId: number,
+    requiresFollowUp: boolean
+  ): void;
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/todo-interfaces/positive/typescript/test.config.json
@@ -1,0 +1,8 @@
+{
+  "id": "parameter-parameter-todo-interfaces-positive-typescript",
+  "name": "TypeScript parameter-parameter data clump between unrelated interfaces",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {}
+}


### PR DESCRIPTION
## Summary
- extend the TypeScript parser to record interface methods and their parameters so interface-only definitions contribute to detection
- add TypeScript and Java parameter-to-parameter scenarios covering unrelated interfaces with positive and negative expectations

## Testing
- yarn run testOnly DataClumpsDetectionTest --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cf3098b0288330945287fa477c4de5