### PR TITLE
Align field-field variable-order scenario names

### DIFF
--- a/tests/data-clumps/test-cases/field-field/variable-order/positive/java/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/variable-order/positive/java/report-expected.json
@@ -38,7 +38,7 @@
   },
   "project_info": {
     "project_url": "unknown",
-    "project_name": "Java field-field data clump with deviated variable order",
+    "project_name": "Java field-field data clump with variable order",
     "project_version": "unknown",
     "project_commit_hash": "unknown",
     "project_tag": null,

--- a/tests/data-clumps/test-cases/field-field/variable-order/positive/java/test.config.json
+++ b/tests/data-clumps/test-cases/field-field/variable-order/positive/java/test.config.json
@@ -1,5 +1,5 @@
 {
-  "name": "Java field-field data clump with deviated variable order",
+  "name": "Java field-field data clump with variable order",
   "language": "java",
   "sourceDir": "source",
   "expectedReportFile": "report-expected.json",

--- a/tests/data-clumps/test-cases/field-field/variable-order/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/variable-order/positive/typescript/report-expected.json
@@ -38,7 +38,7 @@
   },
   "project_info": {
     "project_url": "unknown",
-    "project_name": "TypeScript field-field data clump with deviated variable order",
+    "project_name": "TypeScript field-field data clump with variable order",
     "project_version": "unknown",
     "project_commit_hash": "unknown",
     "project_tag": null,

--- a/tests/data-clumps/test-cases/field-field/variable-order/positive/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/field-field/variable-order/positive/typescript/test.config.json
@@ -1,5 +1,5 @@
 {
-  "name": "TypeScript field-field data clump with deviated variable order",
+  "name": "TypeScript field-field data clump with variable order",
   "language": "typescript",
   "sourceDir": "source",
   "expectedReportFile": "report-expected.json",


### PR DESCRIPTION
## Summary
- rename the field-field variable-order scenario display name in both TypeScript and Java configs to drop the outdated "deviated" wording
- update the corresponding expected report metadata so the project names match the renamed scenario

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68cfb55c115c8330a672eeaa3968afa8