### PR TITLE
Add less-variable data clump detector scenarios

### DIFF
--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/java/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/java/report-expected.json
@@ -1,0 +1,72 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T19:59:00.758Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToClasses": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 0,
+    "amount_files_with_data_clumps": 0,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 0
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java field-field ignored due to higher threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 0,
+    "number_of_data_fields": 4,
+    "number_of_method_parameters": 0
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {}
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/java/source/Doctor.java
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/java/source/Doctor.java
@@ -1,0 +1,9 @@
+public class Doctor {
+    public int recordId;
+    public boolean isActive;
+
+    public Doctor(int recordId, boolean isActive) {
+        this.recordId = recordId;
+        this.isActive = isActive;
+    }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/java/source/Patient.java
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/java/source/Patient.java
@@ -1,0 +1,9 @@
+public class Patient {
+    public int recordId;
+    public boolean isActive;
+
+    public Patient(int recordId, boolean isActive) {
+        this.recordId = recordId;
+        this.isActive = isActive;
+    }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/java/test.config.json
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/java/test.config.json
@@ -1,0 +1,9 @@
+{
+  "name": "Java field-field ignored due to higher threshold",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedFieldsToFieldsAmountMinimum": 3
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/typescript/report-expected.json
@@ -1,0 +1,72 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T19:58:59.021Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToClasses": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 0,
+    "amount_files_with_data_clumps": 0,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 0
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript field-field ignored due to higher threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 0,
+    "number_of_data_fields": 4,
+    "number_of_method_parameters": 0
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {}
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/typescript/source/Doctor.ts
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/typescript/source/Doctor.ts
@@ -1,0 +1,9 @@
+export class Doctor {
+  public recordId: number;
+  public isActive: boolean;
+
+  constructor(recordId: number, isActive: boolean) {
+    this.recordId = recordId;
+    this.isActive = isActive;
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/typescript/source/Patient.ts
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/typescript/source/Patient.ts
@@ -1,0 +1,9 @@
+export class Patient {
+  public recordId: number;
+  public isActive: boolean;
+
+  constructor(recordId: number, isActive: boolean) {
+    this.recordId = recordId;
+    this.isActive = isActive;
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/negative/typescript/test.config.json
@@ -1,0 +1,9 @@
+{
+  "name": "TypeScript field-field ignored due to higher threshold",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedFieldsToFieldsAmountMinimum": 3
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/java/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/java/report-expected.json
@@ -1,0 +1,225 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T19:58:58.314Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToClasses": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 2,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java field-field data clump with lower shared threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 0,
+    "number_of_data_fields": 4,
+    "number_of_method_parameters": 0
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 2,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "fields_to_fields_data_clump-Doctor.java-Doctor-Patient-recordIdisActive": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Doctor.java-Doctor-Patient-recordIdisActive",
+      "probability": 1,
+      "from_file_path": "Doctor.java",
+      "from_class_or_interface_name": "Doctor",
+      "from_class_or_interface_key": "Doctor",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Patient.java",
+      "to_class_or_interface_key": "Patient",
+      "to_class_or_interface_name": "Doctor",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Doctor/memberField/recordId": {
+          "key": "Doctor/memberField/recordId",
+          "name": "recordId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient/memberField/recordId",
+            "name": "recordId",
+            "type": "int",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 2,
+              "startColumn": 16,
+              "endLine": 2,
+              "endColumn": 24
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 16,
+            "endLine": 2,
+            "endColumn": 24
+          }
+        },
+        "Doctor/memberField/isActive": {
+          "key": "Doctor/memberField/isActive",
+          "name": "isActive",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 3,
+              "startColumn": 20,
+              "endLine": 3,
+              "endColumn": 28
+            }
+          },
+          "position": {
+            "startLine": 3,
+            "startColumn": 20,
+            "endLine": 3,
+            "endColumn": 28
+          }
+        }
+      }
+    },
+    "fields_to_fields_data_clump-Patient.java-Patient-Doctor-recordIdisActive": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Patient.java-Patient-Doctor-recordIdisActive",
+      "probability": 1,
+      "from_file_path": "Patient.java",
+      "from_class_or_interface_name": "Patient",
+      "from_class_or_interface_key": "Patient",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Doctor.java",
+      "to_class_or_interface_key": "Doctor",
+      "to_class_or_interface_name": "Patient",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Patient/memberField/recordId": {
+          "key": "Patient/memberField/recordId",
+          "name": "recordId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor/memberField/recordId",
+            "name": "recordId",
+            "type": "int",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 2,
+              "startColumn": 16,
+              "endLine": 2,
+              "endColumn": 24
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 16,
+            "endLine": 2,
+            "endColumn": 24
+          }
+        },
+        "Patient/memberField/isActive": {
+          "key": "Patient/memberField/isActive",
+          "name": "isActive",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 3,
+              "startColumn": 20,
+              "endLine": 3,
+              "endColumn": 28
+            }
+          },
+          "position": {
+            "startLine": 3,
+            "startColumn": 20,
+            "endLine": 3,
+            "endColumn": 28
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/java/source/Doctor.java
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/java/source/Doctor.java
@@ -1,0 +1,9 @@
+public class Doctor {
+    public int recordId;
+    public boolean isActive;
+
+    public Doctor(int recordId, boolean isActive) {
+        this.recordId = recordId;
+        this.isActive = isActive;
+    }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/java/source/Patient.java
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/java/source/Patient.java
@@ -1,0 +1,9 @@
+public class Patient {
+    public int recordId;
+    public boolean isActive;
+
+    public Patient(int recordId, boolean isActive) {
+        this.recordId = recordId;
+        this.isActive = isActive;
+    }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/java/test.config.json
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/java/test.config.json
@@ -1,0 +1,9 @@
+{
+  "name": "Java field-field data clump with lower shared threshold",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedFieldsToFieldsAmountMinimum": 2
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/typescript/report-expected.json
@@ -1,0 +1,185 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T19:58:56.521Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToClasses": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 2,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript field-field data clump with lower shared threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 0,
+    "number_of_data_fields": 4,
+    "number_of_method_parameters": 0
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 2,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "fields_to_fields_data_clump-Doctor.ts-Doctor.ts/class/Doctor-Patient.ts/class/Patient-recordIdisActive": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Doctor.ts-Doctor.ts/class/Doctor-Patient.ts/class/Patient-recordIdisActive",
+      "probability": 1,
+      "from_file_path": "Doctor.ts",
+      "from_class_or_interface_name": "Doctor",
+      "from_class_or_interface_key": "Doctor.ts/class/Doctor",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Patient.ts",
+      "to_class_or_interface_key": "Patient.ts/class/Patient",
+      "to_class_or_interface_name": "Doctor",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Doctor.ts/class/Doctor/memberField/recordId": {
+          "key": "Doctor.ts/class/Doctor/memberField/recordId",
+          "name": "recordId",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/recordId",
+            "name": "recordId",
+            "type": "number",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Doctor.ts/class/Doctor/memberField/isActive": {
+          "key": "Doctor.ts/class/Doctor/memberField/isActive",
+          "name": "isActive",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    },
+    "fields_to_fields_data_clump-Patient.ts-Patient.ts/class/Patient-Doctor.ts/class/Doctor-recordIdisActive": {
+      "type": "data_clump",
+      "key": "fields_to_fields_data_clump-Patient.ts-Patient.ts/class/Patient-Doctor.ts/class/Doctor-recordIdisActive",
+      "probability": 1,
+      "from_file_path": "Patient.ts",
+      "from_class_or_interface_name": "Patient",
+      "from_class_or_interface_key": "Patient.ts/class/Patient",
+      "from_method_name": null,
+      "from_method_key": null,
+      "to_file_path": "Doctor.ts",
+      "to_class_or_interface_key": "Doctor.ts/class/Doctor",
+      "to_class_or_interface_name": "Patient",
+      "to_method_key": null,
+      "to_method_name": null,
+      "data_clump_type": "fields_to_fields_data_clump",
+      "data_clump_data": {
+        "Patient.ts/class/Patient/memberField/recordId": {
+          "key": "Patient.ts/class/Patient/memberField/recordId",
+          "name": "recordId",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor.ts/class/Doctor/memberField/recordId",
+            "name": "recordId",
+            "type": "number",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "Patient.ts/class/Patient/memberField/isActive": {
+          "key": "Patient.ts/class/Patient/memberField/isActive",
+          "name": "isActive",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [
+            "PUBLIC"
+          ],
+          "to_variable": {
+            "key": "Doctor.ts/class/Doctor/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/typescript/source/Doctor.ts
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/typescript/source/Doctor.ts
@@ -1,0 +1,9 @@
+export class Doctor {
+  public recordId: number;
+  public isActive: boolean;
+
+  constructor(recordId: number, isActive: boolean) {
+    this.recordId = recordId;
+    this.isActive = isActive;
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/typescript/source/Patient.ts
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/typescript/source/Patient.ts
@@ -1,0 +1,9 @@
+export class Patient {
+  public recordId: number;
+  public isActive: boolean;
+
+  constructor(recordId: number, isActive: boolean) {
+    this.recordId = recordId;
+    this.isActive = isActive;
+  }
+}

--- a/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/field-field/simple-less-variables/positive/typescript/test.config.json
@@ -1,0 +1,9 @@
+{
+  "name": "TypeScript field-field data clump with lower shared threshold",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedFieldsToFieldsAmountMinimum": 2
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/java/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/java/report-expected.json
@@ -1,0 +1,72 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T19:58:55.845Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 0,
+    "amount_files_with_data_clumps": 0,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 0
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java parameter-field ignored due to higher threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 1,
+    "number_of_data_fields": 2,
+    "number_of_method_parameters": 2
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {}
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/java/source/Patient.java
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/java/source/Patient.java
@@ -1,0 +1,9 @@
+public class Patient {
+    public int recordId;
+    public boolean isActive;
+
+    public Patient(int recordId, boolean isActive) {
+        this.recordId = recordId;
+        this.isActive = isActive;
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/java/source/PatientService.java
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/java/source/PatientService.java
@@ -1,0 +1,5 @@
+public class PatientService {
+    public void registerPatient(int recordId, boolean isActive) {
+        System.out.println("Registering patient " + recordId + " with active status " + isActive);
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/java/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/java/test.config.json
@@ -1,0 +1,9 @@
+{
+  "name": "Java parameter-field ignored due to higher threshold",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedParametersToFieldsAmountMinimum": 3
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/typescript/report-expected.json
@@ -1,0 +1,72 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T19:58:53.928Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 0,
+    "amount_files_with_data_clumps": 0,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 0
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript parameter-field ignored due to higher threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 1,
+    "number_of_data_fields": 2,
+    "number_of_method_parameters": 2
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {}
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/typescript/source/Patient.ts
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/typescript/source/Patient.ts
@@ -1,0 +1,9 @@
+export class Patient {
+  public recordId: number;
+  public isActive: boolean;
+
+  constructor(recordId: number, isActive: boolean) {
+    this.recordId = recordId;
+    this.isActive = isActive;
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/typescript/source/PatientService.ts
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/typescript/source/PatientService.ts
@@ -1,0 +1,5 @@
+export class PatientService {
+  registerPatient(recordId: number, isActive: boolean): void {
+    console.log(`Registering patient ${recordId} with active status ${isActive}`);
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/negative/typescript/test.config.json
@@ -1,0 +1,9 @@
+{
+  "name": "TypeScript parameter-field ignored due to higher threshold",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedParametersToFieldsAmountMinimum": 3
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/java/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/java/report-expected.json
@@ -1,0 +1,145 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T19:58:53.261Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 1,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 1,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 1,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 1
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java parameter-field data clump with lower shared threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 1,
+    "number_of_data_fields": 2,
+    "number_of_method_parameters": 2
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 2,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "parameters_to_fields_data_clump-PatientService.java-PatientService/method/registerPatient(int recordId, boolean isActive)-Patient-recordIdisActive": {
+      "type": "data_clump",
+      "key": "parameters_to_fields_data_clump-PatientService.java-PatientService/method/registerPatient(int recordId, boolean isActive)-Patient-recordIdisActive",
+      "probability": 1,
+      "from_file_path": "PatientService.java",
+      "from_class_or_interface_name": "PatientService",
+      "from_class_or_interface_key": "PatientService",
+      "from_method_name": "registerPatient",
+      "from_method_key": "PatientService/method/registerPatient(int recordId, boolean isActive)",
+      "to_file_path": "Patient.java",
+      "to_class_or_interface_name": "Patient",
+      "to_class_or_interface_key": "Patient",
+      "to_method_name": null,
+      "to_method_key": null,
+      "data_clump_type": "parameters_to_fields_data_clump",
+      "data_clump_data": {
+        "PatientService/method/registerPatient(int recordId, boolean isActive)/parameter/recordId": {
+          "key": "PatientService/method/registerPatient(int recordId, boolean isActive)/parameter/recordId",
+          "name": "recordId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "Patient/memberField/recordId",
+            "name": "recordId",
+            "type": "int",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 2,
+              "startColumn": 16,
+              "endLine": 2,
+              "endColumn": 24
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 37,
+            "endLine": 2,
+            "endColumn": 45
+          }
+        },
+        "PatientService/method/registerPatient(int recordId, boolean isActive)/parameter/isActive": {
+          "key": "PatientService/method/registerPatient(int recordId, boolean isActive)/parameter/isActive",
+          "name": "isActive",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "Patient/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {
+              "startLine": 3,
+              "startColumn": 20,
+              "endLine": 3,
+              "endColumn": 28
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 55,
+            "endLine": 2,
+            "endColumn": 63
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/java/source/Patient.java
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/java/source/Patient.java
@@ -1,0 +1,9 @@
+public class Patient {
+    public int recordId;
+    public boolean isActive;
+
+    public Patient(int recordId, boolean isActive) {
+        this.recordId = recordId;
+        this.isActive = isActive;
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/java/source/PatientService.java
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/java/source/PatientService.java
@@ -1,0 +1,5 @@
+public class PatientService {
+    public void registerPatient(int recordId, boolean isActive) {
+        System.out.println("Registering patient " + recordId + " with active status " + isActive);
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/java/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/java/test.config.json
@@ -1,0 +1,9 @@
+{
+  "name": "Java parameter-field data clump with lower shared threshold",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedParametersToFieldsAmountMinimum": 2
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/typescript/report-expected.json
@@ -1,0 +1,125 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T19:58:51.334Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        },
+        "invertedParameterToMethods": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": null,
+          "maximum": 1,
+          "average": 1,
+          "amountSavedValuesForKeys": 2,
+          "amountKeys": 1
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 1,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 1,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 1,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 1
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript parameter-field data clump with lower shared threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 1,
+    "number_of_data_fields": 2,
+    "number_of_method_parameters": 2
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 2,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "parameters_to_fields_data_clump-PatientService.ts-PatientService.ts/class/PatientService/method/registerPatient-Patient.ts/class/Patient-recordIdisActive": {
+      "type": "data_clump",
+      "key": "parameters_to_fields_data_clump-PatientService.ts-PatientService.ts/class/PatientService/method/registerPatient-Patient.ts/class/Patient-recordIdisActive",
+      "probability": 1,
+      "from_file_path": "PatientService.ts",
+      "from_class_or_interface_name": "PatientService",
+      "from_class_or_interface_key": "PatientService.ts/class/PatientService",
+      "from_method_name": "registerPatient",
+      "from_method_key": "PatientService.ts/class/PatientService/method/registerPatient",
+      "to_file_path": "Patient.ts",
+      "to_class_or_interface_name": "Patient",
+      "to_class_or_interface_key": "Patient.ts/class/Patient",
+      "to_method_name": null,
+      "to_method_key": null,
+      "data_clump_type": "parameters_to_fields_data_clump",
+      "data_clump_data": {
+        "PatientService.ts/class/PatientService/method/registerPatient/parameter/recordId": {
+          "key": "PatientService.ts/class/PatientService/method/registerPatient/parameter/recordId",
+          "name": "recordId",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/recordId",
+            "name": "recordId",
+            "type": "number",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        },
+        "PatientService.ts/class/PatientService/method/registerPatient/parameter/isActive": {
+          "key": "PatientService.ts/class/PatientService/method/registerPatient/parameter/isActive",
+          "name": "isActive",
+          "type": "boolean",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "Patient.ts/class/Patient/memberField/isActive",
+            "name": "isActive",
+            "type": "boolean",
+            "modifiers": [
+              "PUBLIC"
+            ],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/typescript/source/Patient.ts
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/typescript/source/Patient.ts
@@ -1,0 +1,9 @@
+export class Patient {
+  public recordId: number;
+  public isActive: boolean;
+
+  constructor(recordId: number, isActive: boolean) {
+    this.recordId = recordId;
+    this.isActive = isActive;
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/typescript/source/PatientService.ts
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/typescript/source/PatientService.ts
@@ -1,0 +1,5 @@
+export class PatientService {
+  registerPatient(recordId: number, isActive: boolean): void {
+    console.log(`Registering patient ${recordId} with active status ${isActive}`);
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-field/simple-less-variables/positive/typescript/test.config.json
@@ -1,0 +1,9 @@
+{
+  "name": "TypeScript parameter-field data clump with lower shared threshold",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedParametersToFieldsAmountMinimum": 2
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/java/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/java/report-expected.json
@@ -1,0 +1,72 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T20:00:57.571Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToMethods": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 0,
+    "amount_files_with_data_clumps": 0,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 0
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java parameter-parameter ignored due to higher threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 2,
+    "number_of_data_fields": 0,
+    "number_of_method_parameters": 4
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {}
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/java/source/AppointmentScheduler.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/java/source/AppointmentScheduler.java
@@ -1,0 +1,5 @@
+public class AppointmentScheduler {
+    public void schedule(int patientId, int doctorId) {
+        System.out.println("Scheduling appointment for patient " + patientId + " with doctor " + doctorId);
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/java/source/BillingProcessor.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/java/source/BillingProcessor.java
@@ -1,0 +1,5 @@
+public class BillingProcessor {
+    public void createInvoice(int patientId, int doctorId) {
+        System.out.println("Creating invoice for patient " + patientId + " and doctor " + doctorId);
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/java/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/java/test.config.json
@@ -1,0 +1,10 @@
+{
+  "name": "Java parameter-parameter ignored due to higher threshold",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedParametersToParametersAmountMinimum": 3,
+    "sharedParametersToFieldsAmountMinimum": 3
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/typescript/report-expected.json
@@ -1,0 +1,72 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T20:00:55.864Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToMethods": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 0,
+    "amount_files_with_data_clumps": 0,
+    "amount_methods_with_data_clumps": 0,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 0,
+    "amount_data_clumps": 0
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript parameter-parameter ignored due to higher threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 2,
+    "number_of_data_fields": 0,
+    "number_of_method_parameters": 4
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 3,
+      "sharedParametersToFieldsAmountMinimum": 3,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {}
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/typescript/source/AppointmentScheduler.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/typescript/source/AppointmentScheduler.ts
@@ -1,0 +1,5 @@
+export class AppointmentScheduler {
+  schedule(patientId: number, doctorId: number): void {
+    console.log(`Scheduling appointment for patient ${patientId} with doctor ${doctorId}`);
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/typescript/source/BillingProcessor.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/typescript/source/BillingProcessor.ts
@@ -1,0 +1,5 @@
+export class BillingProcessor {
+  createInvoice(patientId: number, doctorId: number): void {
+    console.log(`Creating invoice for patient ${patientId} and doctor ${doctorId}`);
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/negative/typescript/test.config.json
@@ -1,0 +1,10 @@
+{
+  "name": "TypeScript parameter-parameter ignored due to higher threshold",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedParametersToParametersAmountMinimum": 3,
+    "sharedParametersToFieldsAmountMinimum": 3
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/java/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/java/report-expected.json
@@ -1,0 +1,209 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T20:00:55.186Z",
+  "target_language": "java",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToMethods": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 2,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 2,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "Java parameter-parameter data clump with lower shared threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 2,
+    "number_of_data_fields": 0,
+    "number_of_method_parameters": 4
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 2,
+      "sharedParametersToFieldsAmountMinimum": 2,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "parameters_to_parameters_data_clump-AppointmentScheduler.java-AppointmentScheduler/method/schedule(int patientId, int doctorId)-BillingProcessor/method/createInvoice(int patientId, int doctorId)-patientIddoctorId": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-AppointmentScheduler.java-AppointmentScheduler/method/schedule(int patientId, int doctorId)-BillingProcessor/method/createInvoice(int patientId, int doctorId)-patientIddoctorId",
+      "probability": 1,
+      "from_file_path": "AppointmentScheduler.java",
+      "from_class_or_interface_name": "AppointmentScheduler",
+      "from_class_or_interface_key": "AppointmentScheduler",
+      "from_method_name": "schedule",
+      "from_method_key": "AppointmentScheduler/method/schedule(int patientId, int doctorId)",
+      "to_file_path": "BillingProcessor.java",
+      "to_class_or_interface_name": "BillingProcessor",
+      "to_class_or_interface_key": "BillingProcessor",
+      "to_method_name": "createInvoice",
+      "to_method_key": "BillingProcessor/method/createInvoice(int patientId, int doctorId)",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "AppointmentScheduler/method/schedule(int patientId, int doctorId)/parameter/patientId": {
+          "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId)/parameter/patientId",
+          "name": "patientId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId)/parameter/patientId",
+            "name": "patientId",
+            "type": "int",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 35,
+              "endLine": 2,
+              "endColumn": 44
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 30,
+            "endLine": 2,
+            "endColumn": 39
+          }
+        },
+        "AppointmentScheduler/method/schedule(int patientId, int doctorId)/parameter/doctorId": {
+          "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId)/parameter/doctorId",
+          "name": "doctorId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId)/parameter/doctorId",
+            "name": "doctorId",
+            "type": "int",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 50,
+              "endLine": 2,
+              "endColumn": 58
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 45,
+            "endLine": 2,
+            "endColumn": 53
+          }
+        }
+      }
+    },
+    "parameters_to_parameters_data_clump-BillingProcessor.java-BillingProcessor/method/createInvoice(int patientId, int doctorId)-AppointmentScheduler/method/schedule(int patientId, int doctorId)-patientIddoctorId": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-BillingProcessor.java-BillingProcessor/method/createInvoice(int patientId, int doctorId)-AppointmentScheduler/method/schedule(int patientId, int doctorId)-patientIddoctorId",
+      "probability": 1,
+      "from_file_path": "BillingProcessor.java",
+      "from_class_or_interface_name": "BillingProcessor",
+      "from_class_or_interface_key": "BillingProcessor",
+      "from_method_name": "createInvoice",
+      "from_method_key": "BillingProcessor/method/createInvoice(int patientId, int doctorId)",
+      "to_file_path": "AppointmentScheduler.java",
+      "to_class_or_interface_name": "AppointmentScheduler",
+      "to_class_or_interface_key": "AppointmentScheduler",
+      "to_method_name": "schedule",
+      "to_method_key": "AppointmentScheduler/method/schedule(int patientId, int doctorId)",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "BillingProcessor/method/createInvoice(int patientId, int doctorId)/parameter/patientId": {
+          "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId)/parameter/patientId",
+          "name": "patientId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId)/parameter/patientId",
+            "name": "patientId",
+            "type": "int",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 30,
+              "endLine": 2,
+              "endColumn": 39
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 35,
+            "endLine": 2,
+            "endColumn": 44
+          }
+        },
+        "BillingProcessor/method/createInvoice(int patientId, int doctorId)/parameter/doctorId": {
+          "key": "BillingProcessor/method/createInvoice(int patientId, int doctorId)/parameter/doctorId",
+          "name": "doctorId",
+          "type": "int",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler/method/schedule(int patientId, int doctorId)/parameter/doctorId",
+            "name": "doctorId",
+            "type": "int",
+            "modifiers": [],
+            "position": {
+              "startLine": 2,
+              "startColumn": 45,
+              "endLine": 2,
+              "endColumn": 53
+            }
+          },
+          "position": {
+            "startLine": 2,
+            "startColumn": 50,
+            "endLine": 2,
+            "endColumn": 58
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/java/source/AppointmentScheduler.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/java/source/AppointmentScheduler.java
@@ -1,0 +1,5 @@
+public class AppointmentScheduler {
+    public void schedule(int patientId, int doctorId) {
+        System.out.println("Scheduling appointment for patient " + patientId + " with doctor " + doctorId);
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/java/source/BillingProcessor.java
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/java/source/BillingProcessor.java
@@ -1,0 +1,5 @@
+public class BillingProcessor {
+    public void createInvoice(int patientId, int doctorId) {
+        System.out.println("Creating invoice for patient " + patientId + " and doctor " + doctorId);
+    }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/java/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/java/test.config.json
@@ -1,0 +1,10 @@
+{
+  "name": "Java parameter-parameter data clump with lower shared threshold",
+  "language": "java",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedParametersToParametersAmountMinimum": 2,
+    "sharedParametersToFieldsAmountMinimum": 2
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/typescript/report-expected.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/typescript/report-expected.json
@@ -1,0 +1,169 @@
+{
+  "report_version": "^0.1.102",
+  "report_timestamp": "2025-09-21T20:00:53.603Z",
+  "target_language": "typescript",
+  "report_summary": {
+    "additional": {
+      "invertedIndexSoftwareProjectStatistics": {
+        "invertedFieldToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        },
+        "invertedParameterToMethods": {
+          "median": null,
+          "maximum": 2,
+          "average": 2,
+          "amountSavedValuesForKeys": 4,
+          "amountKeys": 1
+        },
+        "invertedParameterToClasses": {
+          "median": 0,
+          "maximum": 0,
+          "average": null,
+          "amountSavedValuesForKeys": 0,
+          "amountKeys": 0
+        }
+      }
+    },
+    "amount_classes_or_interfaces_with_data_clumps": 2,
+    "amount_files_with_data_clumps": 2,
+    "amount_methods_with_data_clumps": 2,
+    "fields_to_fields_data_clump": 0,
+    "parameters_to_fields_data_clump": 0,
+    "parameters_to_parameters_data_clump": 2,
+    "amount_data_clumps": 2
+  },
+  "project_info": {
+    "project_url": "unknown",
+    "project_name": "TypeScript parameter-parameter data clump with lower shared threshold",
+    "project_version": "unknown",
+    "project_commit_hash": "unknown",
+    "project_tag": null,
+    "project_commit_date": null,
+    "additional": {},
+    "number_of_files": 2,
+    "number_of_classes_or_interfaces": 2,
+    "number_of_methods": 2,
+    "number_of_data_fields": 0,
+    "number_of_method_parameters": 4
+  },
+  "detector": {
+    "name": "data-clumps-doctor",
+    "url": "https://github.com/NilsBaumgartner1994/data-clumps-doctor",
+    "version": "0.1.101",
+    "options": {
+      "fastDetection": true,
+      "ignorePaths": [],
+      "similarityModifierOfVariablesWithUnknownType": 0,
+      "minimumSimilarityForDataClumps": 0.5,
+      "fieldsOfClassesWithUnknownHierarchyProbabilityModifier": 0,
+      "sharedFieldsToFieldsAmountMinimum": 3,
+      "analyseFieldsInClassesOrInterfacesInheritedFromSuperClassesOrInterfaces": false,
+      "sharedParametersToParametersAmountMinimum": 2,
+      "sharedParametersToFieldsAmountMinimum": 2,
+      "methodsOfClassesOrInterfacesWithUnknownHierarchyProbabilityModifier": 0,
+      "ignoredVariableNames": []
+    }
+  },
+  "data_clumps": {
+    "parameters_to_parameters_data_clump-AppointmentScheduler.ts-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-patientIddoctorId": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-AppointmentScheduler.ts-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-patientIddoctorId",
+      "probability": 1,
+      "from_file_path": "AppointmentScheduler.ts",
+      "from_class_or_interface_name": "AppointmentScheduler",
+      "from_class_or_interface_key": "AppointmentScheduler.ts/class/AppointmentScheduler",
+      "from_method_name": "schedule",
+      "from_method_key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule",
+      "to_file_path": "BillingProcessor.ts",
+      "to_class_or_interface_name": "BillingProcessor",
+      "to_class_or_interface_key": "BillingProcessor.ts/class/BillingProcessor",
+      "to_method_name": "createInvoice",
+      "to_method_key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/patientId": {
+          "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/patientId",
+          "name": "patientId",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/patientId",
+            "name": "patientId",
+            "type": "number",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        },
+        "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/doctorId": {
+          "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/doctorId",
+          "name": "doctorId",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/doctorId",
+            "name": "doctorId",
+            "type": "number",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    },
+    "parameters_to_parameters_data_clump-BillingProcessor.ts-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-patientIddoctorId": {
+      "type": "data_clump",
+      "key": "parameters_to_parameters_data_clump-BillingProcessor.ts-BillingProcessor.ts/class/BillingProcessor/method/createInvoice-AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule-patientIddoctorId",
+      "probability": 1,
+      "from_file_path": "BillingProcessor.ts",
+      "from_class_or_interface_name": "BillingProcessor",
+      "from_class_or_interface_key": "BillingProcessor.ts/class/BillingProcessor",
+      "from_method_name": "createInvoice",
+      "from_method_key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice",
+      "to_file_path": "AppointmentScheduler.ts",
+      "to_class_or_interface_name": "AppointmentScheduler",
+      "to_class_or_interface_key": "AppointmentScheduler.ts/class/AppointmentScheduler",
+      "to_method_name": "schedule",
+      "to_method_key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule",
+      "data_clump_type": "parameters_to_parameters_data_clump",
+      "data_clump_data": {
+        "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/patientId": {
+          "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/patientId",
+          "name": "patientId",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/patientId",
+            "name": "patientId",
+            "type": "number",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        },
+        "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/doctorId": {
+          "key": "BillingProcessor.ts/class/BillingProcessor/method/createInvoice/parameter/doctorId",
+          "name": "doctorId",
+          "type": "number",
+          "probability": 1,
+          "modifiers": [],
+          "to_variable": {
+            "key": "AppointmentScheduler.ts/class/AppointmentScheduler/method/schedule/parameter/doctorId",
+            "name": "doctorId",
+            "type": "number",
+            "modifiers": [],
+            "position": {}
+          },
+          "position": {}
+        }
+      }
+    }
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/typescript/source/AppointmentScheduler.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/typescript/source/AppointmentScheduler.ts
@@ -1,0 +1,5 @@
+export class AppointmentScheduler {
+  schedule(patientId: number, doctorId: number): void {
+    console.log(`Scheduling appointment for patient ${patientId} with doctor ${doctorId}`);
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/typescript/source/BillingProcessor.ts
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/typescript/source/BillingProcessor.ts
@@ -1,0 +1,5 @@
+export class BillingProcessor {
+  createInvoice(patientId: number, doctorId: number): void {
+    console.log(`Creating invoice for patient ${patientId} and doctor ${doctorId}`);
+  }
+}

--- a/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/typescript/test.config.json
+++ b/tests/data-clumps/test-cases/parameter-parameter/simple-less-variables/positive/typescript/test.config.json
@@ -1,0 +1,10 @@
+{
+  "name": "TypeScript parameter-parameter data clump with lower shared threshold",
+  "language": "typescript",
+  "sourceDir": "source",
+  "expectedReportFile": "report-expected.json",
+  "detectorOptions": {
+    "sharedParametersToParametersAmountMinimum": 2,
+    "sharedParametersToFieldsAmountMinimum": 2
+  }
+}


### PR DESCRIPTION
## Summary
- add simple-less-variables parameter-parameter scenarios for TypeScript and Java with two shared parameters when the detector minimum is set to 2 and confirm they disappear when the threshold is restored to 3
- cover the same two-variable threshold behavior for parameter-field scenarios in both languages
- add field-field variants that exercise detector thresholds with two shared fields

## Testing
- `yarn run testOnly`


------
https://chatgpt.com/codex/tasks/task_e_68d0577f97e88330b19e2918cf4a7f00